### PR TITLE
feat: create UI components breadcrumb

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, Home } from 'lucide-react';
+import Link from 'next/link';
+
+import { cn } from '@/lib/utils';
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<'nav'> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = 'Breadcrumb';
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<'ol'>
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
+      className,
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = 'BreadcrumbList';
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<'li'>
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn('inline-flex items-center gap-1.5', className)}
+    {...props}
+  />
+));
+BreadcrumbItem.displayName = 'BreadcrumbItem';
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<'a'> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn('transition-colors hover:text-foreground', className)}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<'span'>
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn('font-normal text-foreground', className)}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = 'BreadcrumbPage';
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'li'>) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn('[&>svg]:size-3.5', className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
+
+// const BreadcrumbEllipsis = ({
+//   className,
+//   ...props
+// }: React.ComponentProps<'span'>) => (
+//   <span
+//     role="presentation"
+//     aria-hidden="true"
+//     className={cn('flex h-9 w-9 items-center justify-center', className)}
+//     {...props}
+//   >
+//     <MoreHorizontal className="h-4 w-4" />
+//     <span className="sr-only">More</span>
+//   </span>
+// );
+// BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
+
+function BreadcrumbCustomized() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href="/">
+              <Home />
+            </Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current page</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  // BreadcrumbEllipsis,
+  BreadcrumbCustomized,
+};

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,26 +1,30 @@
-import * as React from 'react';
+import {
+  ComponentPropsWithoutRef,
+  forwardRef,
+  ReactNode,
+  ComponentProps,
+} from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { ChevronRight, Home } from 'lucide-react';
-import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
-const Breadcrumb = React.forwardRef<
+const Breadcrumb = forwardRef<
   HTMLElement,
-  React.ComponentPropsWithoutRef<'nav'> & {
-    separator?: React.ReactNode;
+  ComponentPropsWithoutRef<'nav'> & {
+    separator?: ReactNode;
   }
 >(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
 Breadcrumb.displayName = 'Breadcrumb';
 
-const BreadcrumbList = React.forwardRef<
+const BreadcrumbList = forwardRef<
   HTMLOListElement,
-  React.ComponentPropsWithoutRef<'ol'>
+  ComponentPropsWithoutRef<'ol'>
 >(({ className, ...props }, ref) => (
   <ol
     ref={ref}
     className={cn(
-      'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
+      'flex flex-wrap items-center break-words text-sm text-white',
       className,
     )}
     {...props}
@@ -28,46 +32,42 @@ const BreadcrumbList = React.forwardRef<
 ));
 BreadcrumbList.displayName = 'BreadcrumbList';
 
-const BreadcrumbItem = React.forwardRef<
+const BreadcrumbItem = forwardRef<
   HTMLLIElement,
-  React.ComponentPropsWithoutRef<'li'>
+  ComponentPropsWithoutRef<'li'>
 >(({ className, ...props }, ref) => (
   <li
     ref={ref}
-    className={cn('inline-flex items-center gap-1.5', className)}
+    className={cn('inline-flex items-center', className)}
     {...props}
   />
 ));
 BreadcrumbItem.displayName = 'BreadcrumbItem';
 
-const BreadcrumbLink = React.forwardRef<
+const BreadcrumbLink = forwardRef<
   HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<'a'> & {
+  ComponentPropsWithoutRef<'a'> & {
     asChild?: boolean;
   }
 >(({ asChild, className, ...props }, ref) => {
   const Comp = asChild ? Slot : 'a';
 
   return (
-    <Comp
-      ref={ref}
-      className={cn('transition-colors hover:text-foreground', className)}
-      {...props}
-    />
+    <Comp ref={ref} className={cn('transition-colors', className)} {...props} />
   );
 });
 BreadcrumbLink.displayName = 'BreadcrumbLink';
 
-const BreadcrumbPage = React.forwardRef<
+const BreadcrumbPage = forwardRef<
   HTMLSpanElement,
-  React.ComponentPropsWithoutRef<'span'>
+  ComponentPropsWithoutRef<'span'>
 >(({ className, ...props }, ref) => (
   <span
     ref={ref}
     role="link"
     aria-disabled="true"
     aria-current="page"
-    className={cn('font-normal text-foreground', className)}
+    className={cn('font-normal text-2xl', className)}
     {...props}
   />
 ));
@@ -77,53 +77,17 @@ const BreadcrumbSeparator = ({
   children,
   className,
   ...props
-}: React.ComponentProps<'li'>) => (
+}: ComponentProps<'li'>) => (
   <li
     role="presentation"
     aria-hidden="true"
-    className={cn('[&>svg]:size-3.5', className)}
+    className={cn('[&>svg]:size-6', className)}
     {...props}
   >
     {children ?? <ChevronRight />}
   </li>
 );
 BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
-
-// const BreadcrumbEllipsis = ({
-//   className,
-//   ...props
-// }: React.ComponentProps<'span'>) => (
-//   <span
-//     role="presentation"
-//     aria-hidden="true"
-//     className={cn('flex h-9 w-9 items-center justify-center', className)}
-//     {...props}
-//   >
-//     <MoreHorizontal className="h-4 w-4" />
-//     <span className="sr-only">More</span>
-//   </span>
-// );
-// BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
-
-function BreadcrumbCustomized() {
-  return (
-    <Breadcrumb>
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link href="/">
-              <Home />
-            </Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>Current page</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
-  );
-}
 
 export {
   Breadcrumb,
@@ -132,6 +96,4 @@ export {
   BreadcrumbLink,
   BreadcrumbPage,
   BreadcrumbSeparator,
-  // BreadcrumbEllipsis,
-  BreadcrumbCustomized,
 };


### PR DESCRIPTION
## Overview
The task is to create a shared UI component for `breadcrumb`.

## Changes
Added `breadcrumb` component from shadcn/ui and styled it based on [figma](https://www.figma.com/file/5tNJDDfqC0HnHbWygzEXiL/Tascurator?type=design&node-id=0-1&mode=design&t=SvzFH1RdR9OWCQRn-0)

## Screenshots or videos
▼Figma
Without Chevron
<img width="397" alt="Screenshot 2024-04-04 at 10 32 45 PM" src="https://github.com/Tascurator/tascurator-frontend/assets/132441773/864684b3-692d-48ba-82ae-9b8238feafde">

With Chevron
![Screenshot 2024-04-04 at 10 20 52 PM](https://github.com/Tascurator/tascurator-frontend/assets/132441773/1c3606e4-88dd-43da-b2f3-da22b44c0e0b)

▼Sample page(code)
![Screenshot 2024-04-04 at 10 33 57 PM](https://github.com/Tascurator/tascurator-frontend/assets/132441773/1d785f7e-18b4-4d72-9070-09ec008df173)

## Notes(3 notes)
### [1] Deleted Elements: 
I have removed the component represented by the ellipsis (...) in the form of `<BreadcrumbEllipsis />` as there are no plans to utilize it in this project.
![Screenshot 2024-04-04 at 10 25 10 PM](https://github.com/Tascurator/tascurator-frontend/assets/132441773/9f0eedbb-6c1d-48f4-84bb-7fad4508e9b0)

### [2] Regarding the adjusted styles:
**1. Gap Adjustment:**
Initially, a gap of 1.5 was set as default. However, retaining the gap element resulted in excessive spacing when adding the '>' character. Therefore, we have opted to remove the gap. In cases where no '>' character is present, additional margin may be required. Nevertheless, for better flexibility during page creation, we have chosen to maintain consistency without the gap.

**2. Text Color:**
By default, breadcrumb elements other than the current one had a slight gray tint. 
However, to align with the design in Figma, **I have standardized the text color to white** (`text-white`).
Additionally, we have removed the hover settings and kept the color consistent as white. 
(*As discussed and agreed upon during the meeting held on April 4, 2024).

### [3] Confirmation Method:
I'm conducting production confirmation based on the code of the [Link component](https://ui.shadcn.com/docs/components/breadcrumb#link-component). 

▼ Reference: To confirm including the Home icon, you can do so by following the steps below.
```
import { Home } from 'lucide-react';　//Homeアイコンを呼び出す
import Link from 'next/link';

function BreadcrumbCustomized() {
  return (
    <Breadcrumb>
      <BreadcrumbList>
        <BreadcrumbItem>
          <BreadcrumbLink>
            <Link href="/">
              <Home className="w-6 h-6" />
            </Link>
          </BreadcrumbLink>
        </BreadcrumbItem>
        <BreadcrumbSeparator />
        <BreadcrumbItem>
          <BreadcrumbPage>Current page</BreadcrumbPage>
        </BreadcrumbItem>
      </BreadcrumbList>
    </Breadcrumb>
  );
}
```
**Additional note: Regarding the Home icon**
For the Home icon, it's preferable to adjust its size to match the text size, with a width of 24px and a height of 24px (`w-6 h-6`).
*Note: After trying several sizes, we found that this setting was most suitable for the design, so we have implemented it accordingly.

## Assignee Checklist:
- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:
- [x] Code readability and simplicity
- [x] Follows best practices and coding standards
- [x] Understandable and maintainable code
- [x] Don't use wildcard`*` when some components are imported.