### PR TITLE
feat: add routing based on the sitemap

### DIFF
--- a/src/app/[assignment_sheet_id]/[tenant_id]/page.tsx
+++ b/src/app/[assignment_sheet_id]/[tenant_id]/page.tsx
@@ -1,0 +1,21 @@
+interface IAssignmentSheetPageProps {
+  params: {
+    assignment_sheet_id: string;
+    tenant_id: string;
+  };
+}
+
+const AssignmentSheetPage = ({
+  params: { assignment_sheet_id, tenant_id },
+}: IAssignmentSheetPageProps) => {
+  return (
+    <>
+      <p>Assignment Sheet Page</p>
+      <p>
+        Assignment Sheet ID: {assignment_sheet_id}, Tenant ID: {tenant_id}
+      </p>
+    </>
+  );
+};
+
+export default AssignmentSheetPage;

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+const ForgotPasswordPage = () => {
+  return <p>Forgot Password Page</p>;
+};
+
+export default ForgotPasswordPage;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,5 @@
+const NotFound = () => {
+  return <p>404 - Not Found!</p>;
+};
+
+export default NotFound;

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,5 @@
+const ResetPasswordPage = () => {
+  return <p>Reset Password Page</p>;
+};
+
+export default ResetPasswordPage;

--- a/src/app/sharehouses/[share_house_id]/edit/page.tsx
+++ b/src/app/sharehouses/[share_house_id]/edit/page.tsx
@@ -1,0 +1,18 @@
+interface IEditShareHousePageProps {
+  params: {
+    share_house_id: string;
+  };
+}
+
+const EditShareHousePage = ({
+  params: { share_house_id },
+}: IEditShareHousePageProps) => {
+  return (
+    <>
+      <p>Edit Share House Page</p>
+      <p>Share House ID: {share_house_id}</p>
+    </>
+  );
+};
+
+export default EditShareHousePage;

--- a/src/app/sharehouses/[share_house_id]/page.tsx
+++ b/src/app/sharehouses/[share_house_id]/page.tsx
@@ -1,0 +1,18 @@
+interface IShareHousePageProps {
+  params: {
+    share_house_id: string;
+  };
+}
+
+const ShareHousePage = ({
+  params: { share_house_id },
+}: IShareHousePageProps) => {
+  return (
+    <>
+      <p>Share House Page</p>
+      <p>Share House ID: {share_house_id}</p>
+    </>
+  );
+};
+
+export default ShareHousePage;

--- a/src/app/sharehouses/layout.tsx
+++ b/src/app/sharehouses/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+interface IShareHousesLayoutProps {
+  children: ReactNode;
+}
+
+const ShareHousesLayout = ({ children }: IShareHousesLayoutProps) => {
+  return <>{children}</>;
+};
+
+export default ShareHousesLayout;

--- a/src/app/sharehouses/new/page.tsx
+++ b/src/app/sharehouses/new/page.tsx
@@ -1,0 +1,5 @@
+const NewSharehousePage = () => {
+  return <p>New Share House Page</p>;
+};
+
+export default NewSharehousePage;

--- a/src/app/sharehouses/page.tsx
+++ b/src/app/sharehouses/page.tsx
@@ -1,0 +1,9 @@
+const ShareHousesPage = () => {
+  return (
+    <div>
+      <p>All Share Houses Page</p>
+    </div>
+  );
+};
+
+export default ShareHousesPage;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,9 @@
+const SignUpPage = () => {
+  return (
+    <div>
+      <p>Sign Up Page</p>
+    </div>
+  );
+};
+
+export default SignUpPage;


### PR DESCRIPTION
## Overview
Based on the sitemap we created, I've added routing for each page, including the global not-found page and layout for `/sharehouses`.

## Changes
- Here is the list of files added
  - /not-found.tsx
  - /singup/page.tsx
  - /forgot-password/page.tsx
  - /reset-password/page.tsx
  - /sharehouses/page.tsx
  - /sharehouses/layout.tsx
  - /sharehouses/new/page.tsx
  - /sharehouses/[share_house_id]/page.tsx
  - /sharehouses/[share_house_id]/edit/page.tsx
  - /[assignment_sheet_id]/[tenant_id]/page.tsx

## Review points
- I would appreciate it if the reviewers double-check that I correctly added the necessary routes and pages.

## Notes
- For those dynamic routes/pages, I've configured the `params` that can be read or used in the pages.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] Code readability and simplicity
- [x] Follows best practices and coding standards
- [x] Understandable and maintainable code