### PR TITLE
chore: ignore `.idea/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# TypeDoc
 docs
 
 # IDE

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 next-env.d.ts
 
 docs
+
+# IDE
+.idea/


### PR DESCRIPTION
## Overview
The `.idea/` folder, a directory created by JetBrains IDEs, is where to store project-specific settings and configuration files. I've configured it so that it won't be committed automatically.

## Changes
- Added `.idea/` into `.gitignore`

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code