### PR TITLE
docs: add PR title rules in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ If you are interested in the detailed specification you can visit:
 
 ## Pull Requests
 
-When merging pull requests into the `main` branch, we use the "squash and merge" strategy. This approach combines all commits from the branch into a single commit in the `main` branch, ensuring our commit history remains clean and easy to follow.
+When merging pull requests, we use the "squash and merge" strategy. This approach combines all commits from the branch into a single commit, ensuring our commit history remains clean and easy to follow.
 
 ### PR Title Rules
 
@@ -108,7 +108,7 @@ Examples:
 
 ### For Team Members:
 
-1. Create a new branch from the `main` branch.
+1. Create a new branch from the `develop` branch.
 2. Follow the [Branch Rules](#branching-rules) while naming your branch.
 3. Work on your changes locally.
 4. Commit your changes, ensuring to follow the project's [commit message rules](#commit-message-rules).
@@ -120,10 +120,10 @@ Examples:
 
 1. Fork the repository to your own GitHub account.
 2. Clone your forked repository locally.
-3. Create a new branch from the `main` branch on your fork.
+3. Create a new branch from the `develop` branch on your fork.
 4. Follow the [Branching Rules](#branching-rules) while naming your branch.
 5. Work on your changes locally.
 6. Commit your changes, ensuring to follow the project's [commit message rules](#commit-message-rules).
 7. Push your branch to your forked repository.
-8. Create a Pull Request against the `main` branch of the original repository.
+8. Create a Pull Request against the `develop` branch of the original repository.
 9. Await code review, and address any comments as necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This document outlines the guidelines for contributing to the project.
 1. [Branching Rules](#branching-rules)
    - [Types](#types-of-branch)
    - [Examples](#examples-of-branches)
-2. [Commit Message Guidelines](#commit-message-guidelines)
+2. [Commit Message Rules](#commit-message-rules)
    - [Types](#types-of-commit)
    - [Examples](#examples-of-commit-messages)
 3. [Pull Requests](#pull-requests)
@@ -55,7 +55,7 @@ _Note: `<issue_number>-` can be omitted if the modification is not based on an i
 - hotfix/56-security-vulnerability-fix
 - docs/108-update-installation-guide
 
-## Commit Message Guidelines
+## Commit Message Rules
 
 This project follows a following conventional commit message format.
 
@@ -96,7 +96,7 @@ When merging pull requests into the `main` branch, we use the "squash and merge"
 
 ### PR Title Rules
 
-- Follow the same convention rules as the [Commit Message Guidelines](#commit-message-guidelines)
+- Follow the same convention rules as the [Commit Message Rules](#commit-message-rules)
 - Format: `<type>(optional scope): <description>` in lowercase
 
 Examples:
@@ -111,7 +111,7 @@ Examples:
 1. Create a new branch from the `main` branch.
 2. Follow the [Branch Rules](#branching-rules) while naming your branch.
 3. Work on your changes locally.
-4. Commit your changes, ensuring to follow the project's [commit message guidelines](#commit-message-guidelines).
+4. Commit your changes, ensuring to follow the project's [commit message rules](#commit-message-rules).
 5. Push your branch to the repository.
 6. Create a Pull Request against the original branch you branched from.
 7. Await code review, and address any comments as necessary.
@@ -123,7 +123,7 @@ Examples:
 3. Create a new branch from the `main` branch on your fork.
 4. Follow the [Branching Rules](#branching-rules) while naming your branch.
 5. Work on your changes locally.
-6. Commit your changes, ensuring to follow the project's [commit message guidelines](#commit-message-guidelines).
+6. Commit your changes, ensuring to follow the project's [commit message rules](#commit-message-rules).
 7. Push your branch to your forked repository.
 8. Create a Pull Request against the `main` branch of the original repository.
 9. Await code review, and address any comments as necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,15 @@ This document outlines the guidelines for contributing to the project.
 ## Table of Contents
 
 1. [Branching Rules](#branching-rules)
-    - [Types](#types-of-branch)
-    - [Examples](#examples-of-branches)
+   - [Types](#types-of-branch)
+   - [Examples](#examples-of-branches)
 2. [Commit Message Guidelines](#commit-message-guidelines)
-    - [Types](#types-of-commit)
-    - [Examples](#examples-of-commit-messages)
+   - [Types](#types-of-commit)
+   - [Examples](#examples-of-commit-messages)
 3. [Pull Requests](#pull-requests)
-    - [For Team Members](#for-team-members)
-    - [For External Contributors](#for-external-contributors)
+   - [PR Title Rules](#pr-title-rules)
+   - [For Team Members](#for-team-members)
+   - [For External Contributors](#for-external-contributors)
 
 ## Branching Rules
 
@@ -26,27 +27,27 @@ _Note: `<issue_number>-` can be omitted if the modification is not based on an i
 
 - `main`:
 
-    - **Purpose**: For production use.
-    - **Rule**: Direct commits are restricted. Changes arrive via pull requests from `develop` or `hotfix/` branches.
-  
+  - **Purpose**: For production use.
+  - **Rule**: Direct commits are restricted. Changes arrive via pull requests from `develop` or `hotfix/` branches.
+
 - `develop`:
-  
+
   - **Purpose**: For development use.
   - **Rule**: Direct commits are restricted. Changes arrive via pull requests from `feature/`, `hotfix/`, or `docs/` branches.
 
 - `feature/`:
 
-    - **Purpose**: Branches for developing new features or improvements.
-    - **Rule**: After completion and testing, submit a pull request to merge into `develop`.
+  - **Purpose**: Branches for developing new features or improvements.
+  - **Rule**: After completion and testing, submit a pull request to merge into `develop`.
 
 - `hotfix/`:
 
-    - **Purpose**: Branches for urgent fixes.
-    - **Rule**: After fixing, submit a pull request to merge into `develop`. Also, merge the changes into `main` to ensure the fix is present in the production environment.
+  - **Purpose**: Branches for urgent fixes.
+  - **Rule**: After fixing, submit a pull request to merge into `develop`. Also, merge the changes into `main` to ensure the fix is present in the production environment.
 
 - `docs/`:
-    - **Purpose**: Branches for documentation updates.
-    - **Rule**: Submit a pull request to merge updates into `develop`.
+  - **Purpose**: Branches for documentation updates.
+  - **Rule**: Submit a pull request to merge updates into `develop`.
 
 ### Examples of Branches
 
@@ -75,13 +76,13 @@ This project follows a following conventional commit message format.
 
 - Bad: `Made changes to login`
 - Good examples:
-    - `feat: introduce user profiles`
-    - `fix: resolve memory leak in user sessions`
-    - `docs(api): enhance API endpoint documentation`
-    - `style(widgets): adjust widget styling for consistency`
-    - `refactor: improve query efficiency`
-    - `test: cover user deletion scenarios`
-    - `chore: upgrade to webpack 5`
+  - `feat: introduce user profiles`
+  - `fix: resolve memory leak in user sessions`
+  - `docs(api): enhance API endpoint documentation`
+  - `style(widgets): adjust widget styling for consistency`
+  - `refactor: improve query efficiency`
+  - `test: cover user deletion scenarios`
+  - `chore: upgrade to webpack 5`
 
 If you are interested in the detailed specification you can visit:
 
@@ -92,6 +93,18 @@ If you are interested in the detailed specification you can visit:
 ## Pull Requests
 
 When merging pull requests into the `main` branch, we use the "squash and merge" strategy. This approach combines all commits from the branch into a single commit in the `main` branch, ensuring our commit history remains clean and easy to follow.
+
+### PR Title Rules
+
+- Follow the same convention rules as the [Commit Message Guidelines](#commit-message-guidelines)
+- Format: `<type>(optional scope): <description>` in lowercase
+
+Examples:
+
+- `feat: add user authentication system`
+- `fix: resolve navigation bar overlap issue`
+- `refactor: improve error handling in payment gateway`
+- `test(API): increase coverage for user authentication tests`
 
 ### For Team Members:
 


### PR DESCRIPTION
## Overview

The PR title rules were missing in the `CONTRIBUTING.md`, so I've added them.

## Changes
- Modified the `CONTRIBUTING.md` by adding the PR title rules, correcting branch names, and replacing words for uniformity

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code