### PR TITLE
feat: add destructive variant to `Input` component

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -25,6 +25,17 @@ export interface IInputProps
   icon?: ReactNode;
 }
 
+/**
+ * An input component
+ *
+ * @example
+ * // A default input
+ * <Input type="text" placeholder="Enter your name" />
+ * // A destructive input
+ * <Input variant="destructive" type="text" placeholder="Enter your name" />
+ * // An input with an icon
+ * <Input icon={<SearchIcon />} type="text" placeholder="Search" />
+ */
 const Input = forwardRef<HTMLInputElement, IInputProps>(
   ({ className, variant, type, icon, ...props }, ref) => {
     return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -39,7 +39,7 @@ export interface IInputProps
 const Input = forwardRef<HTMLInputElement, IInputProps>(
   ({ className, variant, type, icon, ...props }, ref) => {
     return (
-      <div className="relative">
+      <div className="relative w-full">
         {icon && (
           <div className="absolute inset-y-0 right-3 flex items-center">
             {icon}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
   className?: string;
-  icon?: JSX.Element;
+  variant: 'primary' | 'secondary';
   icon?: ReactNode;
 }
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
+const Input = forwardRef<HTMLInputElement, IInputProps>(
   ({ className, type, icon, ...props }, ref) => {
     return (
       <div className="relative">

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,14 +1,32 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-export interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
+const inputVariants = cva(
+  'w-full h-12 rounded-xl border px-3 py-2 ring-offset-background placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'border-input bg-background focus-visible:ring-ring',
+        destructive:
+          'border-destructive bg-destructive-background focus-visible:ring-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface IInputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {
   className?: string;
-  variant: 'primary' | 'secondary';
   icon?: ReactNode;
 }
 
 const Input = forwardRef<HTMLInputElement, IInputProps>(
-  ({ className, type, icon, ...props }, ref) => {
+  ({ className, variant, type, icon, ...props }, ref) => {
     return (
       <div className="relative">
         {icon && (
@@ -18,10 +36,7 @@ const Input = forwardRef<HTMLInputElement, IInputProps>(
         )}
         <input
           type={type}
-          className={cn(
-            'w-full h-12 rounded-xl border border-input bg-background px-3 py-2 ring-offset-background placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-            className,
-          )}
+          className={cn(inputVariants({ variant, className }))}
           ref={ref}
           {...props}
         />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   className?: string;
   icon?: JSX.Element;
+  icon?: ReactNode;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(


### PR DESCRIPTION
## Overview
We needed to have a destructive variant for validation fails, as we no longer use the `Form` component from `shadcn/ui`.

## Changes
- Added destructive variant
- Added TSDoc
- Corrected `interface` name to match our standards
- Corrected the type of the `icon` prop
- Set to use parent's 100% width

## Screenshots or videos

https://github.com/Tascurator/tascurator-frontend/assets/124953279/91a75672-7c03-4f73-83cf-95c65bfe4301

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code