### PR TITLE
feat: add max-width and background adjustments for larger screen sizes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={cn(
-          'flex justify-center items-start w-screen h-screen bg-primary-lightest',
+          'flex justify-center items-start w-screen min-h-screen bg-primary-lightest',
           roboto.className,
         )}
       >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,11 +20,11 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={cn(
-          'flex justify-center items-start w-screen h-screen',
+          'flex justify-center items-start w-screen h-screen bg-primary-lightest',
           roboto.className,
         )}
       >
-        <main className={'max-w-screen-sm w-full h-full px-6 border'}>
+        <main className={'max-w-screen-sm w-full h-full bg-white px-6 border'}>
           {children}
         </main>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
           roboto.className,
         )}
       >
-        <main className={'max-w-screen-sm w-full h-full bg-white px-6 border'}>
+        <main className={'max-w-screen-sm w-full h-full bg-white px-6'}>
           {children}
         </main>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { Roboto } from 'next/font/google';
 import './globals.css';
+import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
 
 const roboto = Roboto({ weight: ['400', '500'], subsets: ['latin'] });
 
@@ -12,11 +14,20 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">
-      <body className={roboto.className}>{children}</body>
+      <body
+        className={cn(
+          'flex justify-center items-start w-screen h-screen',
+          roboto.className,
+        )}
+      >
+        <main className={'max-w-screen-sm w-full h-full px-6 border'}>
+          {children}
+        </main>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Overview
I've limited the maximum width to avoid stretching very wide horizontally, especially on desktop screen. Also, I've added background color and x-axis padding. These changes have been done in the root `layout.tsx`.

## Changes

- Set the max-width to 640px for the main content, equivalent to the `sm` breakpoint in Tailwind CSS
- Set the background color to the color, `primary-lightest`
- Set the x-axis padding to 24px, according to Figma

## Screenshots or videos

https://github.com/Tascurator/tascurator-frontend/assets/124953279/9d33e9b6-af95-4aeb-b34c-8538fdb4a214

## Notes
The Figma didn't mention the max-width and background color, but @HrRn decided on those after some discussion with me.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] Code readability and simplicity
- [x] Follows best practices and coding standards
- [x] Understandable and maintainable code