### PR TITLE
fix: support opacity modifier for custom colors

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,36 +10,36 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: 'rgb(var(--color-primary))',
-          light: 'rgb(var(--color-primary-light))',
-          lightest: 'rgb(var(--color-primary-lightest))',
+          DEFAULT: 'rgba(var(--color-primary), <alpha-value>)',
+          light: 'rgba(var(--color-primary-light), <alpha-value>)',
+          lightest: 'rgba(var(--color-primary-lightest), <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'rgb(var(--color-secondary))',
-          light: 'rgb(var(--color-secondary-light))',
+          DEFAULT: 'rgba(var(--color-secondary), <alpha-value>)',
+          light: 'rgba(var(--color-secondary-light), <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'rgb(var(--color-destructive))',
+          DEFAULT: 'rgba(var(--color-destructive), <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'rgb(var(--color-accent))',
+          DEFAULT: 'rgba(var(--color-accent), <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'rgb(var(--muted))',
+          DEFAULT: 'rgba(var(--muted), <alpha-value>)',
         },
         popover: {
-          DEFAULT: 'rgb(var(--popover))',
+          DEFAULT: 'rgba(var(--popover), <alpha-value>)',
         },
         card: {
-          DEFAULT: 'rgb(var(--card))',
+          DEFAULT: 'rgba(var(--card), <alpha-value>)',
         },
-        background: 'rgb(var(--background))',
-        black: 'rgb(var(--color-black))',
-        overlay: 'rgb(var(--color-overlay))',
-        input: 'rgb(var(--input))',
-        border: 'rgb(var(--border))',
-        ring: 'rgb(var(--ring))',
-        placeholder: 'rgb(var(--placeholder))',
+        background: 'rgba(var(--background), <alpha-value>)',
+        black: 'rgba(var(--color-black), <alpha-value>)',
+        overlay: 'rgba(var(--color-overlay), <alpha-value>)',
+        input: 'rgba(var(--input), <alpha-value>)',
+        border: 'rgba(var(--border), <alpha-value>)',
+        ring: 'rgba(var(--ring), <alpha-value>)',
+        placeholder: 'rgba(var(--placeholder), <alpha-value>)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Overview
It is now possible to use the Tailwind's opacity modifier for custom theme colors.

## Changes
- Modified the `tailwind.config.ts` to support the custom opacity

## Notes

I noticed that it can change the opacity by only replacing `rgb` with `rgba`, but I also added `<alpha-value>` in each color to follow what the [official documentation](https://tailwindcss.com/docs/customizing-colors#using-css-variables) says.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code