### PR TITLE
feat: add password visibility toggle in `Input` component

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -47,6 +47,8 @@ export type TInputProps = TInputPropsWithIcon | TInputPropsWithoutIcon;
  * <Input variant="destructive" type="text" placeholder="Enter your name" />
  * // An input with an icon
  * <Input icon={<SearchIcon />} type="text" placeholder="Search" />
+ * // A password input with toggle visibility, no need to pass icons
+ * <Input type="password" placeholder="Enter your password" />
  */
 const Input = forwardRef<HTMLInputElement, TInputProps>(
   ({ className, variant, type, icon, ...props }, ref) => {


### PR DESCRIPTION
## Overview
I've added the password visibility toggle in the `Input` component. If the type is set to `password`, it automatically places the password visibility toggle in the input box.

## Changes
- Added password visibility toggle
- Added padding to the right of the input field to avoid input text being hidden by the icon 

## Screenshots or videos

https://github.com/Tascurator/tascurator-frontend/assets/124953279/1b52b027-6382-419f-a580-01c2365a717d


## Notes

I used 12px for both the right-side padding and padding between the input field and the icon, even though they were 16px according to Figma. I initially tried to follow the 16px, but I had to add padding to the right of the input field and ended up realizing that Tailwind does not have 52px (16px padding + 20px icon + 16px padding), which ensures there's no overwrap for the input text and the icon. [Now, I'm using `pr-11` that is 44px (12px padding + 20px icon + 12px padding).](https://github.com/Tascurator/tascurator-frontend/blob/47db2d33e25215ce1e57421499693a706a11989a/src/components/ui/input.tsx#L88)

![image](https://github.com/Tascurator/tascurator-frontend/assets/124953279/79424ed0-afee-41b1-baf0-af5c09793e93)

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code