### PR TITLE
feat: update variants and sizes in `Button` component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,7 +25,6 @@ const buttonVariants = cva(
       size: {
         default: 'w-64 h-12 px-4 py-2',
         md: 'w-40 h-12 px-4 py-2',
-        sm: 'w-32 h-12 px-4 py-2',
         floating: 'w-14 h-14',
       },
     },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         secondary: 'border border-primary bg-white hover:bg-slate-100',
         tertiary: 'bg-gray-500 text-white hover:bg-gray-500/50',
         destructive: 'bg-rose-600 text-white hover:opacity-80',
-        link: 'text-sky-600 hover:text-[#0084C580] hover:opacity-50 text-base',
+        link: 'text-sky-600 hover:text-[#0084C580] text-base',
         floating:
           'border border-transparent bg-white rounded-full shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),0px_-4px_4px_0px_rgba(0,0,0,0.05)] hover:shadow-md',
         outline:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,6 @@ const buttonVariants = cva(
         default: 'bg-primary text-white hover:opacity-80',
         secondary: 'border border-primary bg-white hover:bg-slate-100',
         tertiary: 'bg-gray-500 text-white hover:bg-gray-500/50',
-        disable: 'bg-white border border-color-gray-500 text-gray-500',
         destructive: 'bg-rose-600 text-white hover:opacity-80',
         link: 'text-sky-600 hover:text-[#0084C580] hover:opacity-50 text-base',
         floating:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -36,7 +36,7 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,10 +9,10 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-white hover:opacity-80',
+        default: 'bg-primary text-white hover:bg-primary/80',
         secondary: 'border border-primary bg-white hover:bg-slate-100',
         tertiary: 'bg-gray-500 text-white hover:bg-gray-500/50',
-        destructive: 'bg-rose-600 text-white hover:opacity-80',
+        destructive: 'bg-rose-600 text-white hover:bg-rose-600/80',
         link: 'text-sky-600 hover:text-[#0084C580] text-base',
         floating:
           'border border-transparent bg-white rounded-full shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),0px_-4px_4px_0px_rgba(0,0,0,0.05)] hover:shadow-md',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,6 +20,7 @@ const buttonVariants = cva(
           'border border-gray-500 bg-background hover:bg-slate-100 hover:text-accent-foreground',
         'outline-destructive':
           'border border-rose-600 bg-background text-rose-600 font-medium hover:bg-slate-100',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {
         default: 'w-64 h-12 px-4 py-2',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           'border border-transparent bg-white rounded-full shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),0px_-4px_4px_0px_rgba(0,0,0,0.05)] hover:shadow-md',
         outline:
           'border border-gray-500 bg-background hover:bg-slate-100 hover:text-accent-foreground',
+        'outline-destructive':
+          'border border-rose-600 bg-background text-rose-600 font-medium hover:bg-slate-100',
       },
       size: {
         default: 'w-64 h-12 px-4 py-2',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,8 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-white hover:opacity-80',
-        secondary:
-          'border border-primary bg-white hover:bg-slate-300 hover:opacity-50 hover:border-slate-300 ',
+        secondary: 'border border-primary bg-white hover:bg-slate-100',
         disable: 'bg-white border border-color-gray-500 text-gray-500',
         destructive: 'bg-rose-600 text-white hover:opacity-80',
         link: 'text-sky-600 hover:text-[#0084C580] hover:opacity-50 text-base',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,6 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-primary text-white hover:opacity-80',
         secondary: 'border border-primary bg-white hover:bg-slate-100',
+        tertiary: 'bg-gray-500 text-white hover:bg-gray-500/50',
         disable: 'bg-white border border-color-gray-500 text-gray-500',
         destructive: 'bg-rose-600 text-white hover:opacity-80',
         link: 'text-sky-600 hover:text-[#0084C580] hover:opacity-50 text-base',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,6 @@ const buttonVariants = cva(
           'border border-transparent bg-white rounded-full shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),0px_-4px_4px_0px_rgba(0,0,0,0.05)] hover:shadow-md',
         outline:
           'border border-gray-500 bg-background hover:bg-slate-100 hover:text-accent-foreground',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {
         default: 'w-64 h-12 px-4 py-2',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         floating:
           'border border-transparent bg-white rounded-full shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25),0px_-4px_4px_0px_rgba(0,0,0,0.05)] hover:shadow-md',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          'border border-gray-500 bg-background hover:bg-slate-100 hover:text-accent-foreground',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'w-64 h-12 px-4 py-2',
-        md: 'w-40 h-12 px-3',
+        md: 'w-40 h-12 px-4 py-2',
         sm: 'w-32 h-12 px-4 py-2',
         floating: 'w-14 h-14',
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
       size: {
         default: 'w-64 h-12 px-4 py-2',
         md: 'w-40 h-12 px-3',
+        sm: 'w-32 h-12 px-4 py-2',
         floating: 'w-14 h-14',
       },
     },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,6 +20,8 @@ const buttonVariants = cva(
           'border border-gray-500 bg-background hover:bg-slate-100 hover:text-accent-foreground',
         'outline-destructive':
           'border border-rose-600 bg-background text-rose-600 font-medium hover:bg-slate-100',
+
+        // This only used for the calendar component. We normally don't use this variant.
         ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'w-64 h-12 px-4 py-2',
-        sm: 'w-40 h-12 px-3',
+        md: 'w-40 h-12 px-3',
         floating: 'w-14 h-14',
       },
     },


### PR DESCRIPTION
## Overview
I've modified the `Button` component to have the same variants and sizes as in our Figma.

## Changes

- Added `tertiary` variant for `Back` buttons
- Added `outline` variant for `Cancel` buttons
- Added `outline-destructive` variant for `Log Out` buttons
- Added `sm` size
- Corrected the padding for `md` size
- Removed unused `disable` variant
- Correct the background color on hover for `secondary` variant
- Utilized Tailwind's background color opacity modifier on hover, rather than changing the button's entire opacity, for `default` and `destructive` buttons

## Review points
Please feel free to suggest better names for the `tertiary`, `outline`, and `outline-destructive` variants. I'm sure there are more conventional names available.

## Screenshots or videos
This video shows all the variants, sizes, and hover styles.

https://github.com/Tascurator/tascurator-frontend/assets/124953279/57fc4499-243a-4b6c-8291-13c734d76ead

## Notes

- For the `sm` size, the width should be `124px` according to Figma, but it doesn't exist in Tailwind CSS. Therefore, I used `w-32` which is `128px` instead.
<img width="632" alt="image" src="https://github.com/Tascurator/tascurator-frontend/assets/124953279/2667788f-7a8b-4fcb-b75f-55f0d973bfc3">

- For the `ghost` variant, this variant is only used by the `Calendar` component. This variant should not be used during our development, so it might be necessary to replace it with a different variant to avoid confusion.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code