### PR TITLE
fix: resolve main content not taking up whole screen

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,9 @@ export default function RootLayout({
           roboto.className,
         )}
       >
-        <main className={'max-w-screen-sm w-full h-full bg-white px-6'}>
+        <main
+          className={'max-w-screen-sm min-h-screen w-full h-full bg-white px-6'}
+        >
           {children}
         </main>
       </body>


### PR DESCRIPTION
## Overview

I've made sure that the main content expands to 100% screen viewport.

## Changes

- Added `min-h-screen` in `layout.tsx`

## Screenshots or videos

![screencapture-localhost-3000-test-2024-05-21-11_02_38](https://github.com/Tascurator/tascurator-frontend/assets/124953279/6b69cfe5-2938-471e-b41d-3b8f9272c6fc)

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code