### PR TITLE
feat: add option to display label together in `Input` component

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -47,6 +47,7 @@ export type TInputProps = TInputPropsWithIcon | TInputPropsWithoutIcon;
 
 /**
  * An input component
+ * Use `classNames` to pass custom classes to the input or label
  *
  * @example
  * // A default input
@@ -55,8 +56,14 @@ export type TInputProps = TInputPropsWithIcon | TInputPropsWithoutIcon;
  * <Input variant="destructive" type="text" placeholder="Enter your name" />
  * // An input with an icon
  * <Input icon={<SearchIcon />} type="text" placeholder="Search" />
+ * // An input with a label
+ * <Input type="email" placeholder="Enter your email" label="Email" />
  * // A password input with toggle visibility, no need to pass icons
  * <Input type="password" placeholder="Enter your password" />
+ *
+ * // Custom styles
+ * // "input" is for the input field, and "label" is for the label
+ * <Input classNames={{ input: 'custom-style', label: 'custom-style' }} />
  */
 const Input = forwardRef<HTMLInputElement, TInputProps>(
   ({ classNames, label, variant, type, icon, ...props }, ref) => {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -19,9 +19,17 @@ const inputVariants = cva(
   },
 );
 
-type TInputPropsBase = InputHTMLAttributes<HTMLInputElement> &
+// Omit className from InputHTMLAttributes as classNames (plural) is used instead
+type TInputPropsBase = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'className'
+> &
   VariantProps<typeof inputVariants> & {
-    className?: string;
+    classNames?: {
+      input?: string;
+      label?: string;
+    };
+    label?: string;
   };
 
 type TInputPropsWithIcon = TInputPropsBase & {
@@ -51,7 +59,7 @@ export type TInputProps = TInputPropsWithIcon | TInputPropsWithoutIcon;
  * <Input type="password" placeholder="Enter your password" />
  */
 const Input = forwardRef<HTMLInputElement, TInputProps>(
-  ({ className, variant, type, icon, ...props }, ref) => {
+  ({ classNames, label, variant, type, icon, ...props }, ref) => {
     const [showPassword, setShowPassword] = useState(false);
 
     const togglePasswordVisibility = () => {
@@ -60,9 +68,9 @@ const Input = forwardRef<HTMLInputElement, TInputProps>(
 
     const inputType = type === 'password' && showPassword ? 'text' : type;
 
-    return (
+    const InputField = (
       <div className="relative w-full">
-        {type === 'password' ? (
+        {type === 'password' && (
           <button
             type="button"
             onClick={togglePasswordVisibility}
@@ -74,7 +82,9 @@ const Input = forwardRef<HTMLInputElement, TInputProps>(
               <EyeIcon className="size-5" />
             )}
           </button>
-        ) : (
+        )}
+
+        {icon && (
           <div className="absolute inset-y-0 right-3 flex items-center">
             {icon}
           </div>
@@ -83,15 +93,32 @@ const Input = forwardRef<HTMLInputElement, TInputProps>(
         <input
           type={inputType}
           className={cn(
-            inputVariants({ variant, className }),
+            inputVariants({ variant }),
             // Add padding to the right to avoid input text being hidden by the icon
             (type === 'password' || icon) && 'pr-11',
+            classNames?.input,
           )}
           ref={ref}
           {...props}
         />
       </div>
     );
+
+    // If label is passed, wrap the input field with a div.
+    // This is to avoid unnecessary nesting when label is not passed.
+    if (label) {
+      return (
+        <div className="w-full flex flex-col space-y-1.5">
+          <label className={cn('w-full text-base', classNames?.label)}>
+            {label}
+          </label>
+          {InputField}
+        </div>
+      );
+    }
+
+    // Return the input field if label is not passed
+    return InputField;
   },
 );
 Input.displayName = 'Input';


### PR DESCRIPTION
## Overview
I've updated the `Input` component to display a label together with the input field.

## Changes

- Added `label` prop (text) to the `Input` component that will be rendered above the input field if provided.
- Updated the styling approach by adding a `classNames` prop instead of `className`, allowing separate styles for the label and the input field.

## Notes

- Here is how to use the `Intput` component with the new `classNames` prop.
```jsx
<Input classNames={{ input: 'custom-style', label: 'custom-style' }} />
```
- The `input` is for the additional styles applied to the input field.
- The `label` is for the additional styles applied to the label.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code