### PR TITLE
feat: add a constant file for error messages

### DIFF
--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -1,0 +1,23 @@
+/**
+ * Error messages for form validation.
+ *
+ * @example
+ * const schema = z.object({
+ *  email: z.string().email(ERROR_MESSAGES.EMAIL),
+ *  password: z.string().min(8, ERROR_MESSAGES.minLength('Password', 8)),
+ * });
+ */
+export const ERROR_MESSAGES = {
+  // Dynamic error messages
+  required: (field: string) => `${field} is required.`,
+  string: (field: string) => `${field} must be a string.`,
+  number: (field: string) => `${field} must be a number.`,
+  minLength: (field: string, min: number) =>
+    `${field} must be at least ${min} characters long.`,
+  maxLength: (field: string, max: number) =>
+    `${field} must be at most ${max} characters long.`,
+  exists: (field: string) => `The ${field.toLowerCase()} already exists.`,
+
+  //Static error messages
+  EMAIL_INVALID: 'Invalid email address.',
+};


### PR DESCRIPTION
## Overview
I've added a constant file for error messages. The error messages are mainly for the input fields. I made most of the messages reusable, meaning it's necessary to pass certain props to use one.

## Changes

- Added `src/constants/error-messages.ts`

## Review points

Please check if the error messages that are possibly used in this app are listed in the file.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code