### PR TITLE
feat: add a constant file for dropdown items

### DIFF
--- a/src/constants/dropdown-items.tsx
+++ b/src/constants/dropdown-items.tsx
@@ -17,41 +17,47 @@ interface IDropdownItems {
  * This file contains all the dropdown items used in the application.
  */
 export const DROPDOWN_ITEMS: IDropdownItems = {
-  // Add
-  ADD_TASK: {
-    icon: <CirclePlusIcon />,
-    text: 'Add task',
+  // ShareHouse
+  EDIT_SHAREHOUSE_NAME: {
+    icon: <SquarePenIcon />,
+    text: 'Edit share house name',
+  },
+  DELETE_SHAREHOUSE: {
+    icon: <Trash2Icon />,
+    text: 'Delete share house',
   },
 
-  // Delete
-  DELETE: {
-    icon: <Trash2Icon />,
-    text: 'Delete',
+  // Category
+  EDIT_CATEGORY_NAME: {
+    icon: <SquarePenIcon />,
+    text: 'Edit category name',
   },
   DELETE_CATEGORY: {
     icon: <Trash2Icon />,
     text: 'Delete category',
   },
 
-  // Edit
-  EDIT: {
-    icon: <SquarePenIcon />,
-    text: 'Edit',
-  },
-  EDIT_SHAREHOUSE: {
-    icon: <SquarePenIcon />,
-    text: 'Edit share house name',
-  },
-  EDIT_CATEGORY_NAME: {
-    icon: <SquarePenIcon />,
-    text: 'Edit category name',
+  // Task
+  ADD_TASK: {
+    icon: <CirclePlusIcon />,
+    text: 'Add task',
   },
   EDIT_TASK: {
     icon: <NotebookPenIcon />,
     text: 'Edit task',
   },
+  DELETE_TASK: {
+    icon: <Trash2Icon />,
+    text: 'Delete task',
+  },
+
+  // Tenant
   EDIT_TENANT: {
     icon: <SquarePenIcon />,
-    text: 'Edit tenant',
+    text: 'Edit tenant setting',
+  },
+  DELETE_TENANT: {
+    icon: <Trash2Icon />,
+    text: 'Delete tenant',
   },
 };

--- a/src/constants/dropdown-items.tsx
+++ b/src/constants/dropdown-items.tsx
@@ -1,0 +1,57 @@
+import {
+  CirclePlusIcon,
+  NotebookPenIcon,
+  SquarePenIcon,
+  Trash2Icon,
+} from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface IDropdownItems {
+  [key: string]: {
+    icon: ReactNode;
+    text: string;
+  };
+}
+
+/**
+ * This file contains all the dropdown items used in the application.
+ */
+export const DROPDOWN_ITEMS: IDropdownItems = {
+  // Add
+  ADD_TASK: {
+    icon: <CirclePlusIcon />,
+    text: 'Add task',
+  },
+
+  // Delete
+  DELETE: {
+    icon: <Trash2Icon />,
+    text: 'Delete',
+  },
+  DELETE_CATEGORY: {
+    icon: <Trash2Icon />,
+    text: 'Delete category',
+  },
+
+  // Edit
+  EDIT: {
+    icon: <SquarePenIcon />,
+    text: 'Edit',
+  },
+  EDIT_SHAREHOUSE: {
+    icon: <SquarePenIcon />,
+    text: 'Edit share house name',
+  },
+  EDIT_CATEGORY_NAME: {
+    icon: <SquarePenIcon />,
+    text: 'Edit category name',
+  },
+  EDIT_TASK: {
+    icon: <NotebookPenIcon />,
+    text: 'Edit task',
+  },
+  EDIT_TENANT: {
+    icon: <SquarePenIcon />,
+    text: 'Edit tenant',
+  },
+};


### PR DESCRIPTION
## Overview
I've listed the combinations of an icon and text in a file for reusability and maintainability.

## Changes

- Added `src/constants/dropdown-items.tsx`

## Review points

Please check if all the combinations are listed in the file.

## Notes
I've changed some of the texts due to the inconsistency as follows:

<img width="1141" alt="Screenshot 2024-05-27 at 22 25 23" src="https://github.com/Tascurator/tascurator-frontend/assets/124953279/a96f6ab6-2938-4c4b-8a24-be9e0aef4c49">


## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code