### PR TITLE
fix: correct overlay color display issue

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,7 +35,7 @@ module.exports = {
         },
         background: 'rgba(var(--background), <alpha-value>)',
         black: 'rgba(var(--color-black), <alpha-value>)',
-        overlay: 'rgba(var(--color-overlay), <alpha-value>)',
+        overlay: 'rgba(var(--color-overlay))',
         input: 'rgba(var(--input), <alpha-value>)',
         border: 'rgba(var(--border), <alpha-value>)',
         ring: 'rgba(var(--ring), <alpha-value>)',


### PR DESCRIPTION
## Overview
I've fixed the issue where the drawer's overlay wasn't displaying as expected.

## Changes

- Removed `<alpha-value>` from the custom color `overlay` in `tailwind.config.ts`, otherwise the defined opacity in the `globals.css` didn't apply

## Screenshots or videos
As you can see, the background color is now applied.
<img width="528" alt="image" src="https://github.com/Tascurator/tascurator-frontend/assets/124953279/2b440d37-e4f3-4123-b3ba-edab0783f0e7">

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code