### PR TITLE
feat: modify spacing and overflow in the `DrawerDescription` component

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -198,7 +198,7 @@ const DrawerDescription = forwardRef<
   <DrawerPrimitive.Description
     ref={ref}
     className={cn(
-      'w-full h-full px-6 mt-5 mb-10 max-w-screen-sm overflow-y-auto',
+      'w-full h-full px-6 mt-5 mb-10 max-w-screen-sm overflow-y-auto break-words text-wrap',
       className,
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -198,7 +198,7 @@ const DrawerDescription = forwardRef<
   <DrawerPrimitive.Description
     ref={ref}
     className={cn(
-      'w-full h-full px-6 pt-5 pb-10 max-w-screen-sm overflow-y-auto',
+      'w-full h-full px-6 mt-5 mb-10 max-w-screen-sm overflow-y-auto',
       className,
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -118,7 +118,7 @@ const DrawerContent = forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col items-center rounded-t-xl border bg-background',
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto max-h-full flex-col items-center rounded-t-xl border bg-background',
         className,
       )}
       {...props}
@@ -197,7 +197,10 @@ const DrawerDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn('w-full px-6 pt-5 pb-10 max-w-screen-sm', className)}
+    className={cn(
+      'w-full h-full px-6 pt-5 pb-10 max-w-screen-sm overflow-y-auto',
+      className,
+    )}
     {...props}
   />
 ));


### PR DESCRIPTION
## Overview

I've adjusted the `DrawerDescription` component to enhance its usability when content overflows. Specifically, I've made the component scrollable and refined the spacing by replacing y-axis paddings with margins for better visual separation during scrolling.

## Changes

- Made the `DrawerDescription` scrollable by setting height and overflow classes
- Changed the y-axis paddings with margins 
- Added `break-words` and `text-wrap` for extremely long words

## Screenshots or videos

https://github.com/Tascurator/tascurator-frontend/assets/124953279/5587a190-87db-461a-9a75-463781ef50cf

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code