### PR TITLE
feat: move drag handle to `DrawerTitle`

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -112,7 +112,7 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 const DrawerContent = forwardRef<
   ElementRef<typeof DrawerPrimitive.Content>,
   ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <DrawerPortal>
     <DrawerOverlay />
     <DrawerPrimitive.Content
@@ -122,10 +122,7 @@ const DrawerContent = forwardRef<
         className,
       )}
       {...props}
-    >
-      <div className="mx-auto my-4 h-2 w-24 rounded-full bg-primary-lightest" />
-      {children}
-    </DrawerPrimitive.Content>
+    />
   </DrawerPortal>
 ));
 DrawerContent.displayName = 'DrawerContent';
@@ -166,20 +163,23 @@ const DrawerTitle = forwardRef<
   ElementRef<typeof DrawerPrimitive.Title>,
   ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <div
-    className={
-      'w-full flex justify-center items-center text-left border-b border-b-slate-300'
-    }
-  >
-    <DrawerPrimitive.Title
-      ref={ref}
-      className={cn(
-        'w-full flex items-center text-2xl px-6 py-2.5 max-w-screen-sm',
-        className,
-      )}
-      {...props}
-    />
-  </div>
+  <>
+    <div className="mx-auto my-4 h-2 w-24 rounded-full bg-primary-lightest" />
+    <div
+      className={
+        'w-full flex justify-center items-center text-left border-b border-b-slate-300'
+      }
+    >
+      <DrawerPrimitive.Title
+        ref={ref}
+        className={cn(
+          'w-full flex items-center text-2xl px-6 py-2.5 max-w-screen-sm',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  </>
 ));
 DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 


### PR DESCRIPTION
## Overview

I've moved the drag handle to the `DrawerTitle` to make it possible to set the `asChild` prop to `true` for the `DrawerContent` component.

## Changes

- Relocated the drag handle to the `DrawerTitle`

## Notes
- According to our Figma, I noticed that a title was essential for each drawer, so I decided to move the drag handle to the `DrawerTitle` component.
- Thus, it is now possible to wrap an element like `form` like below.
```jsx
 <Drawer>
    <DrawerTrigger asChild>
      <Button>Open Drawer</Button>
    </DrawerTrigger>
    <DrawerContent asChild>
      <form action="xxxxxxx'>
        <DrawerTitle>Hello world</DrawerTitle>
        <DrawerDescription>
          <p>
            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras at
            augue laoreet, varius neque a, commodo massa. Maecenas maximus
            ac quam vel tincidunt. Mauris vitae ornare dolor, et egestas
            quam. Fusce vestibulu
          </p>
        </DrawerDescription>
        <DrawerFooter>
          <Button>Submit</Button>
          <DrawerClose asChild>
            <Button variant="outline">Cancel</Button>
          </DrawerClose>
        </DrawerFooter>
      </form>
    </DrawerContent>
  </Drawer>
```

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code