### PR TITLE
feat: add database seeding file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,28 @@ Fifth, generate the Prisma client:
 npm run prisma:generate
 ```
 
+Sixth, seed the database:
+
+```bash
+npm run prisma:seed
+```
+
 Lastly, run the development server:
 
 ```bash
 npm run dev
+```
+
+## Custom Scripts
+
+### Prisma
+
+#### Reset the database
+
+If you want to reset the database with the initial seed data, you can run the following command:
+
+```bash
+npm run prisma:reset
 ```
 
 ## Document

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "prettier": "3.2.5",
         "prisma": "^5.15.1",
         "tailwindcss": "^3.3.0",
+        "ts-node": "^10.9.2",
         "typedoc": "^0.25.13",
         "typedoc-theme-hierarchy": "^4.1.2",
         "typescript": "^5"
@@ -697,6 +698,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2047,6 +2070,30 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
@@ -2173,7 +2220,7 @@
       "version": "20.11.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
       "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2449,7 +2496,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2464,6 +2511,18 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "devOptional": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -3414,6 +3473,12 @@
         "typescript": ">=4"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3690,6 +3755,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -6540,6 +6614,12 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -9231,6 +9311,55 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9406,7 +9535,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9434,7 +9563,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -9635,6 +9764,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "node_modules/vaul": {
       "version": "0.9.0",
@@ -9961,6 +10096,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "prettier": "3.2.5",
     "prisma": "^5.15.1",
     "tailwindcss": "^3.3.0",
+    "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
     "typedoc-theme-hierarchy": "^4.1.2",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prisma:migrate": "dotenv -e .env.local -- prisma migrate dev",
     "prisma:push": "dotenv -e .env.local -- prisma db push",
     "prisma:generate": "dotenv -e .env.local -- prisma generate",
-    "prisma:reset": "dotenv -e .env.local -- prisma migrate reset --force",
+    "prisma:reset": "dotenv -e .env.local -- prisma migrate reset",
     "prisma:seed": "dotenv -e .env.local -- prisma db seed"
   },
   "prisma": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "prisma": "dotenv -e .env.local -- prisma studio",
     "prisma:migrate": "dotenv -e .env.local -- prisma migrate dev",
     "prisma:push": "dotenv -e .env.local -- prisma db push",
-    "prisma:generate": "dotenv -e .env.local -- prisma generate"
+    "prisma:generate": "dotenv -e .env.local -- prisma generate",
+    "prisma:reset": "dotenv -e .env.local -- prisma migrate reset --force",
+    "prisma:seed": "dotenv -e .env.local -- prisma db seed"
+  },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/prisma/migrations/20240620010644_fix_description_assigned_data_types/migration.sql
+++ b/prisma/migrations/20240620010644_fix_description_assigned_data_types/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Changed the type of `assignedData` on the `AssignmentSheet` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "AssignmentSheet" DROP COLUMN "assignedData",
+ADD COLUMN     "assignedData" JSONB NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,7 +39,7 @@ model AssignmentSheet {
   id           String      @id @default(uuid())
   startDate    DateTime
   endDate      DateTime
-  assignedData String      @db.Text
+  assignedData Json
   ShareHouse   ShareHouse?
 }
 
@@ -55,7 +55,7 @@ model Category {
 model Task {
   id          String @id @default(uuid())
   title       String
-  description String
+  description String @db.Text
   categoryId  String
 
   category Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,19 +36,19 @@ const createShareHouse = async (
   });
 };
 
-interface Task {
+interface ITask {
   title: string;
   description: string;
 }
 
-interface Category {
+interface ICategory {
   name: string;
-  tasks: Task[];
+  tasks: ITask[];
 }
 
 const createRotationAssignment = async (
   shareHouseId: string,
-  categories: Category[],
+  categories: ICategory[],
   placeholderCount: number,
 ) => {
   const tenantPlaceholders = Array.from(
@@ -134,7 +134,7 @@ const main = async () => {
   const landlord = await createLandlord();
   console.log('✅ Created landlord\n');
 
-  const categories: Category[] = [
+  const categories: ICategory[] = [
     {
       name: 'Cleaning',
       tasks: [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,311 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { generateAssignedData } from '../src/utils/assigned-data';
+
+const prisma = new PrismaClient();
+
+const createLandlord = async () => {
+  return prisma.landlord.create({
+    data: {
+      email: 'hoge@tascurator.com',
+      password: 'password',
+    },
+  });
+};
+
+const createAssignmentSheet = async () => {
+  return prisma.assignmentSheet.create({
+    data: {
+      startDate: new Date('2025-01-01T00:00:00Z'),
+      endDate: new Date('2025-01-08T00:00:00Z'),
+      assignedData: '',
+    },
+  });
+};
+
+const createShareHouse = async (
+  landlordId: string,
+  assignmentSheetId: string,
+  shareHouseName: string,
+) => {
+  return prisma.shareHouse.create({
+    data: {
+      name: shareHouseName,
+      landlordId,
+      assignmentSheetId,
+    },
+  });
+};
+
+interface Task {
+  title: string;
+  description: string;
+}
+
+interface Category {
+  name: string;
+  tasks: Task[];
+}
+
+const createRotationAssignment = async (
+  shareHouseId: string,
+  categories: Category[],
+  placeholderCount: number,
+) => {
+  const tenantPlaceholders = Array.from(
+    { length: placeholderCount },
+    (_, index) => ({ index }),
+  );
+
+  return prisma.rotationAssignment.create({
+    data: {
+      shareHouseId,
+      rotationCycle: 7,
+      categories: {
+        create: categories.map((category) => ({
+          name: category.name,
+          tasks: {
+            create: category.tasks.map((task) => ({
+              title: task.title,
+              description: task.description,
+            })),
+          },
+        })),
+      },
+      tenantPlaceholders: {
+        create: tenantPlaceholders.map((placeholder) => ({
+          index: placeholder.index,
+        })),
+      },
+    },
+  });
+};
+
+const createTenant = async (email: string, name: string) => {
+  return prisma.tenant.create({
+    data: {
+      email,
+      name,
+      extraAssignedCount: 0,
+    },
+  });
+};
+
+const linkTenantToPlaceholder = async (
+  rotationAssignmentId: string,
+  index: number,
+  tenantId: string,
+) => {
+  return prisma.tenantPlaceholder.update({
+    where: {
+      rotationAssignmentId_index: {
+        rotationAssignmentId,
+        index,
+      },
+    },
+    data: {
+      tenantId,
+    },
+  });
+};
+
+/**
+ * Seed the database with the following data:
+ * - 1 landlord
+ * - 3 share houses with different configurations
+ *   - Categories = Tenants
+ *     - 4 categories with some tasks
+ *     - 4 tenant placeholders
+ *     - 4 tenants
+ *   - Categories > Tenants
+ *     - 4 categories with some tasks
+ *     - 3 tenant placeholders
+ *     - 3 tenants
+ *   - Categories < Tenants
+ *     - 3 categories with some tasks
+ *     - 4 tenant placeholders
+ *     - 4 tenants
+ * - Each tenant is linked to a tenant placeholder
+ * - Rotation assignment record and assignment sheet are created for each share house
+ * - Assigned data is generated and set for each rotation assignment record
+ */
+const main = async () => {
+  console.log(`🌱 Seeding database...\n`);
+
+  const landlord = await createLandlord();
+  console.log('✅ Created landlord\n');
+
+  const categories: Category[] = [
+    {
+      name: 'Cleaning',
+      tasks: [
+        {
+          title: 'Clean the kitchen',
+          description: 'Ensure the kitchen is clean and tidy.',
+        },
+        {
+          title: 'Vacuum living room',
+          description: 'Vacuum the living room floor.',
+        },
+      ],
+    },
+    {
+      name: 'Gardening',
+      tasks: [
+        {
+          title: 'Water the plants',
+          description: 'Water all plants in the garden.',
+        },
+        { title: 'Mow the lawn', description: 'Mow the lawn in the garden.' },
+        {
+          title: 'Weed the garden',
+          description: 'Remove all weeds from the garden.',
+        },
+      ],
+    },
+    {
+      name: 'Grocery shopping',
+      tasks: [
+        {
+          title: 'Buy groceries',
+          description: 'Buy groceries for the house.',
+        },
+        {
+          title: 'Buy toilet paper',
+          description: 'Buy toilet paper for the house.',
+        },
+        {
+          title: 'Buy cleaning supplies',
+          description: 'Buy cleaning supplies for the house.',
+        },
+        {
+          title: 'Buy trash bags',
+          description: 'Buy trash bags for the house.',
+        },
+        {
+          title: 'Buy laundry detergent',
+          description: 'Buy laundry detergent for the house.',
+        },
+      ],
+    },
+    {
+      name: 'Miscellaneous',
+      tasks: [
+        {
+          title: 'Take out the trash',
+          description: 'Take out the trash from the house.',
+        },
+        {
+          title: 'Do the laundry',
+          description: 'Do the laundry for the house.',
+        },
+        {
+          title: 'Clean the bathroom',
+          description: 'Ensure the bathroom is clean and tidy.',
+        },
+        {
+          title: 'Clean the living room',
+          description: 'Ensure the living room is clean and tidy.',
+        },
+      ],
+    },
+  ];
+
+  // It will create 3 share houses with different configurations
+  const shareHouseNames = [
+    'Categories = Tenants',
+    'Categories > Tenants',
+    'Categories < Tenants',
+  ];
+
+  for (let i = 0; i < shareHouseNames.length; i++) {
+    console.log(
+      '------------------------------------------------------------\n',
+    );
+
+    const shareHouseName = shareHouseNames[i];
+    // For the third share house, only use the first two categories
+    const shareHouseCategories = i === 2 ? categories.slice(0, 3) : categories;
+
+    console.log(`▶️ Start creating share house with name: ${shareHouseName}`);
+
+    const assignmentSheet = await createAssignmentSheet();
+    console.log('✅ Created assignment sheet');
+
+    const shareHouse = await createShareHouse(
+      landlord.id,
+      assignmentSheet.id,
+      shareHouseName,
+    );
+    console.log('✅ Created share house');
+
+    const rotationAssignment = await createRotationAssignment(
+      shareHouse.id,
+      shareHouseCategories,
+      4,
+    );
+    console.log(
+      `✅ Created rotation assignment with ${shareHouseCategories.length} categories and 4 tenant placeholders`,
+    );
+
+    const tenant1 = await createTenant(
+      `tenant1+${i}@example.com`,
+      'Tenant One',
+    );
+    const tenant2 = await createTenant(
+      `tenant2+${i}@example.com`,
+      'Tenant Two',
+    );
+    const tenant3 = await createTenant(
+      `tenant3+${i}@example.com`,
+      'Tenant Three',
+    );
+    await linkTenantToPlaceholder(rotationAssignment.id, 0, tenant1.id);
+    await linkTenantToPlaceholder(rotationAssignment.id, 1, tenant2.id);
+    await linkTenantToPlaceholder(rotationAssignment.id, 2, tenant3.id);
+
+    if (i !== 1) {
+      const tenant4 = await createTenant(
+        `tenant4+${i}@example.com`,
+        'Tenant Four',
+      );
+      await linkTenantToPlaceholder(rotationAssignment.id, 3, tenant4.id);
+    }
+    console.log(
+      `✅ Created ${i !== 1 ? 4 : 3} tenants and linked to tenant placeholders`,
+    );
+
+    const assignedData = await generateAssignedData(
+      prisma,
+      rotationAssignment.id,
+    );
+    console.log(
+      '✅ Generated assigned data\n',
+      JSON.stringify(assignedData, null, 2),
+    );
+
+    await prisma.assignmentSheet.update({
+      where: { id: assignmentSheet.id },
+      data: {
+        assignedData: assignedData as unknown as Prisma.JsonArray,
+      },
+    });
+    console.log('✅ Updated assignment sheet with assigned data');
+
+    console.log(`🎉 Finished creating share house: ${shareHouseName}`);
+    console.log(
+      '\n------------------------------------------------------------',
+    );
+  }
+
+  console.log('\n🎉🎉🎉🎉 Seeding successful! Yay! 🎉🎉🎉🎉');
+};
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * PrismaClient is attached to the `global` object in development to prevent
+ * exhausting your database connection limit.
+ *
+ * Learn more:
+ * https://pris.ly/d/help/next-js-best-practices
+ */
+
+const prismaClientSingleton = () => {
+  return new PrismaClient();
+};
+
+declare const globalThis: {
+  prismaGlobal: ReturnType<typeof prismaClientSingleton>;
+} & typeof global;
+
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton();
+
+export default prisma;
+
+if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma;

--- a/src/utils/assigned-data.ts
+++ b/src/utils/assigned-data.ts
@@ -1,0 +1,227 @@
+import { PrismaClient } from '@prisma/client';
+
+interface ITenant {
+  id: string;
+  name: string;
+}
+
+interface IAssignedTask {
+  id: string;
+  name: string;
+  description: string;
+  isCompleted: boolean;
+}
+
+interface IAssignedCategory {
+  category: { id: string; name: string } | null;
+  tenantPlaceholderId: number | null;
+  tenant: ITenant | null;
+  tasks: IAssignedTask[] | null;
+}
+
+export interface IAssignedData {
+  assignments: IAssignedCategory[];
+}
+
+/**
+ * Generate assigned data based on the rotation assignment and tenant placeholders
+ *
+ * if Categories === Tenants
+ *   Assign each category to a tenant
+ * else if Categories < Tenants
+ *   Assign each category to a tenant
+ *   Assign the remaining tenants to no categories with no tasks
+ * else if Categories > Tenants
+ *   Assign each category to a tenant
+ *   Assign the remaining categories to a tenant with the least number of extra assignments
+ *
+ * @param prisma - The Prisma client
+ * @param rotationAssignmentId - The ID of the rotation assignment
+ * @returns The assigned data object
+ */
+export const generateAssignedData = async (
+  prisma: PrismaClient,
+  rotationAssignmentId: string,
+): Promise<IAssignedData> => {
+  /**
+   * Retrieve rotation assignment with categories and their tasks
+   */
+  const rotationAssignmentWithCategories =
+    await prisma.rotationAssignment.findUnique({
+      where: { id: rotationAssignmentId },
+      include: {
+        categories: {
+          include: { tasks: true },
+        },
+      },
+    });
+
+  /**
+   * Retrieve tenant placeholders related to the rotation assignment
+   */
+  const tenantPlaceholders = await prisma.tenantPlaceholder.findMany({
+    where: { rotationAssignmentId },
+    include: { tenant: true },
+  });
+
+  /**
+   * Check if rotation assignment or tenant placeholders are missing (should not happen)
+   */
+  if (!rotationAssignmentWithCategories || tenantPlaceholders.length === 0) {
+    console.error('Rotation assignment or tenant placeholders not found');
+    return { assignments: [] };
+  }
+
+  /**
+   * Initialize the head placeholder index to 0
+   *
+   * TODO: Implement an algorithm to dynamically set the head of the tenant placeholders based on the last rotation's assigned data
+   */
+  let headPlaceholderIndex = 0;
+
+  /**
+   * Initialize the assigned data object with an empty assignments array
+   */
+  const assignedData: IAssignedData = { assignments: [] };
+
+  /**
+   * Helper function to get the tenant placeholder by index
+   *
+   * @param index - The index of the tenant placeholder
+   * @returns The tenant placeholder object or null if not found
+   */
+  const getTenantPlaceholderByIndex = (index: number) => {
+    return (
+      tenantPlaceholders.find((placeholder) => placeholder.index === index) ||
+      null
+    );
+  };
+
+  /**
+   * Helper function to get the tenant with the least number of extra assignments
+   *
+   * @returns The tenant with the least number of extra assignments
+   */
+  const getTenantWithLeastAssignments = () => {
+    return tenantPlaceholders
+      .filter((tp) => tp.tenant)
+      .sort(
+        (a, b) => a.tenant!.extraAssignedCount - b.tenant!.extraAssignedCount,
+      )[0].tenant;
+  };
+
+  /**
+   * Iterate through each category and assign a tenant and tasks to it
+   *
+   * TODO: Implement an algorithm to rotate the tenants based on the last rotation's assigned data
+   */
+  for (const category of rotationAssignmentWithCategories.categories) {
+    /**
+     * Retrieve the tenant placeholder by index
+     */
+    const foundPlaceholder = getTenantPlaceholderByIndex(headPlaceholderIndex);
+    /**
+     * Retrieve the tenant from the tenant placeholder
+     * or
+     * retrieve the tenant with the least number of extra assignments if the tenant placeholder is not found
+     */
+    const tenant = foundPlaceholder?.tenant ?? getTenantWithLeastAssignments();
+
+    /**
+     * Assign the category to the tenant with the tenant placeholder index
+     *
+     * The object structure for the assigned category should be:
+     * if Categories === Tenants:
+     * {
+     *   category: { id: string, name: string },
+     *   tenantPlaceholderId: number,
+     *   tenant: { id: string, name: string },
+     *   tasks: [{ id: string, name: string, description: string, isCompleted: boolean }, ...],
+     * }
+     *
+     * if Categories < Tenants:
+     * {
+     *   category: { id: string, name: string },
+     *   tenantPlaceholderId: null,
+     *   tenant: { id: string, name: string },
+     *   tasks: [{ id: string, name: string, description: string, isCompleted: boolean }, ...],
+     * }
+     */
+    const assignedCategory: IAssignedCategory = {
+      category: { id: category.id, name: category.name },
+      tenantPlaceholderId: foundPlaceholder?.tenant
+        ? foundPlaceholder?.index ?? null
+        : null,
+      tenant: tenant ? { id: tenant.id, name: tenant.name } : null,
+      tasks: category.tasks.map((task) => ({
+        id: task.id,
+        name: task.title,
+        description: task.description,
+        isCompleted: Boolean(Math.round(Math.random())), // 1/2 chance of being completed
+      })),
+    };
+
+    /**
+     * Add the assigned category to the assignments array
+     */
+    assignedData.assignments.push(assignedCategory);
+
+    /**
+     * Increase the head placeholder index
+     */
+    if (headPlaceholderIndex === tenantPlaceholders.length - 1) {
+      headPlaceholderIndex = 0;
+    } else headPlaceholderIndex++;
+  }
+
+  /**
+   * If there are more tenants than categories, assign the remaining tenants to no categories with no tasks.
+   * Also, increase the extra assigned count for each tenant.
+   *
+   * The object structure for the extra tenants should be:
+   * {
+   *   category: null,
+   *   tenantPlaceholderId: null,
+   *   tenant: { id: string, name: string },
+   *   tasks: null,
+   * }
+   */
+  if (assignedData.assignments.length < tenantPlaceholders.length) {
+    const assignedTenants = assignedData.assignments.map(
+      (assignment) => assignment.tenant?.id,
+    );
+    const extraTenants = tenantPlaceholders
+      .filter(
+        (placeholder) => !assignedTenants.includes(placeholder.tenant?.id),
+      )
+      .map((placeholder) => ({
+        category: null,
+        tenantPlaceholderId: placeholder.index,
+        tenant: placeholder.tenant
+          ? { id: placeholder.tenant.id, name: placeholder.tenant.name }
+          : null,
+        tasks: null,
+      }));
+
+    /**
+     * Increase the extra assigned count for each tenant
+     */
+    for (const extraCategory of extraTenants) {
+      await prisma.tenant.update({
+        where: { id: extraCategory.tenant?.id },
+        data: {
+          extraAssignedCount: {
+            increment: 1,
+          },
+        },
+      });
+    }
+
+    /**
+     * Add the extra tenants to the assignments array
+     */
+    assignedData.assignments.push(...extraTenants);
+  }
+
+  return assignedData;
+};


### PR DESCRIPTION
## Overview

I've created a database seeding file with methods to construct the `AssignedData` in the `AssignmentSheet` table.

## Changes

- Created `prisma/seed.ts`
- Created business logic to generate the `AssignedData` in `src/utils/assigned-data.ts` 
- Corrected data type of `Task's description` and `AssignedData` in the `prisma/schema.prisma`
- Updated the `README.me`

## Notes

Please proceed with seeding by typing `npm run prisma:seed`. If you have already added some data to the database and you want to seed while resetting the database, please type `npm run prisma:reset` in your terminal.

The business logic to generate an `AssignedData` is not complete, and I left some TODOs in the file. I'll improve the function later in the development.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code