### PR TITLE
feat: list all common types in `commons.ts`

### DIFF
--- a/src/app/api/[[...route]]/routes/sharehouses.ruote.ts
+++ b/src/app/api/[[...route]]/routes/sharehouses.ruote.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
-import type { IAssignedData } from '@/utils/assigned-data';
+import type { IAssignedData } from '@/types/commons';
 
 const app = new Hono();
 

--- a/src/components/ui/drawers/TaskCreationDrawer.tsx
+++ b/src/components/ui/drawers/TaskCreationDrawer.tsx
@@ -22,14 +22,12 @@ import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { taskCreationSchema, TTaskCreationSchema } from '@/constants/schema';
 import { INPUT_TEXTS } from '@/constants/input-texts';
+import type { ITask as ITaskType } from '@/types/commons';
 
 const { CATEGORY_NAME, TASK_TITLE, TASK_DESCRIPTION } = INPUT_TEXTS;
 
-interface ITask {
-  id: string;
+interface ITask extends ITaskType {
   category: string;
-  title: string;
-  description: string;
 }
 
 enum Syntax {

--- a/src/components/ui/drawers/TenantInvitationDrawer.tsx
+++ b/src/components/ui/drawers/TenantInvitationDrawer.tsx
@@ -17,14 +17,9 @@ import {
   TTenantInvitationSchema,
 } from '@/constants/schema';
 import { INPUT_TEXTS } from '@/constants/input-texts';
+import { ITenant } from '@/types/commons';
 
 const { TENANT_NAME, TENANT_EMAIL } = INPUT_TEXTS;
-
-interface ITenant {
-  id: string;
-  name: string;
-  email: string;
-}
 
 interface IEditTenantDrawer {
   tenant?: ITenant;

--- a/src/components/ui/tenantList.tsx
+++ b/src/components/ui/tenantList.tsx
@@ -13,14 +13,9 @@ import { TenantInvitationDrawer } from '@/components/ui/drawers/TenantInvitation
 import { DeleteConfirmationDrawer } from '@/components/ui/drawers/DeleteConfirmationDrawer';
 import { useState } from 'react';
 import { DROPDOWN_ITEMS } from '@/constants/dropdown-items';
+import type { ITenant } from '@/types/commons';
 
 const { EDIT_TENANT, DELETE_TENANT } = DROPDOWN_ITEMS;
-
-interface ITenant {
-  id: string;
-  name: string;
-  email: string;
-}
 
 interface ITenantListItemProps {
   tenant: ITenant;

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -1,0 +1,69 @@
+/**
+ * The object structure for ShareHouse
+ */
+export interface IShareHouse {
+  id: string;
+  name: string;
+}
+
+/**
+ * The object structure for Category
+ */
+export interface ICategory {
+  id: string;
+  name: string;
+  tasks: ITask[];
+}
+
+/**
+ * The object structure for Task
+ */
+export interface ITask {
+  id: string;
+  title: string;
+  description: string;
+}
+
+/**
+ * The object structure for Tenant
+ */
+export interface ITenant {
+  id: string;
+  name: string;
+  email: string;
+}
+
+/**
+ * The object structure for TenantPlaceholder
+ *
+ * @note This type is mainly used in the backend.
+ */
+export interface IAssignedTask {
+  id: string;
+  title: string;
+  description: string;
+  isCompleted: boolean;
+}
+
+/**
+ * The object structure for AssignedCategory
+ *
+ * @note This type is mainly used in the backend.
+ */
+export interface IAssignedCategory {
+  category: { id: string; name: string } | null;
+  tenantPlaceholderId: number | null;
+  tenant: Omit<ITenant, 'email'> | null;
+  tasks: IAssignedTask[] | null;
+}
+
+/**
+ * The object structure for AssignedData.
+ *
+ * This replicates the JSON structure of the assignedData in the AssignmentSheet table.
+ *
+ * @note This type is mainly used in the backend.
+ */
+export interface IAssignedData {
+  assignments: IAssignedCategory[];
+}

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -38,10 +38,7 @@ export interface ITenant {
  *
  * @note This type is mainly used in the backend.
  */
-export interface IAssignedTask {
-  id: string;
-  title: string;
-  description: string;
+export interface IAssignedTask extends ITask {
   isCompleted: boolean;
 }
 
@@ -51,7 +48,7 @@ export interface IAssignedTask {
  * @note This type is mainly used in the backend.
  */
 export interface IAssignedCategory {
-  category: { id: string; name: string } | null;
+  category: Omit<ICategory, 'tasks'> | null;
   tenantPlaceholderId: number | null;
   tenant: Omit<ITenant, 'email'> | null;
   tasks: IAssignedTask[] | null;

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -34,7 +34,7 @@ export interface ITenant {
 }
 
 /**
- * The object structure for TenantPlaceholder
+ * The object structure for AssignedTask
  *
  * @note This type is mainly used in the backend.
  */
@@ -58,7 +58,7 @@ export interface IAssignedCategory {
 }
 
 /**
- * The object structure for AssignedData.
+ * The object structure for AssignedData
  *
  * This replicates the JSON structure of the assignedData in the AssignmentSheet table.
  *

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -7,21 +7,21 @@ export interface IShareHouse {
 }
 
 /**
- * The object structure for Category
- */
-export interface ICategory {
-  id: string;
-  name: string;
-  tasks: ITask[];
-}
-
-/**
  * The object structure for Task
  */
 export interface ITask {
   id: string;
   title: string;
   description: string;
+}
+
+/**
+ * The object structure for Category
+ */
+export interface ICategory {
+  id: string;
+  name: string;
+  tasks: ITask[];
 }
 
 /**

--- a/src/utils/assigned-data.ts
+++ b/src/utils/assigned-data.ts
@@ -1,27 +1,9 @@
 import { PrismaClient } from '@prisma/client';
-
-interface ITenant {
-  id: string;
-  name: string;
-}
-
-interface IAssignedTask {
-  id: string;
-  name: string;
-  description: string;
-  isCompleted: boolean;
-}
-
-interface IAssignedCategory {
-  category: { id: string; name: string } | null;
-  tenantPlaceholderId: number | null;
-  tenant: ITenant | null;
-  tasks: IAssignedTask[] | null;
-}
-
-export interface IAssignedData {
-  assignments: IAssignedCategory[];
-}
+import type {
+  IAssignedCategory,
+  IAssignedData,
+  IAssignedTask,
+} from '@/types/commons';
 
 /**
  * Generate assigned data based on the rotation assignment and tenant placeholders
@@ -153,12 +135,14 @@ export const generateAssignedData = async (
         ? foundPlaceholder?.index ?? null
         : null,
       tenant: tenant ? { id: tenant.id, name: tenant.name } : null,
-      tasks: category.tasks.map((task) => ({
-        id: task.id,
-        name: task.title,
-        description: task.description,
-        isCompleted: Boolean(Math.round(Math.random())), // 1/2 chance of being completed
-      })),
+      tasks: category.tasks.map(
+        (task): IAssignedTask => ({
+          id: task.id,
+          title: task.title,
+          description: task.description,
+          isCompleted: Boolean(Math.round(Math.random())), // 1/2 chance of being completed
+        }),
+      ),
     };
 
     /**


### PR DESCRIPTION
## Overview

I've created a `commons.ts` that lists all the common types such as `Category` and `Task`. I also have modified some files to use the types from this file.

## Changes

- Listed all the possible common types: ShareHouse, Category, Task, Tenant, AssignedCategory, AssignedTask, AssignedData
- Refactored to utilize these common types throughout the application

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code