### PR TITLE
fix: change header component export from default export to named export

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -174,7 +174,7 @@ interface IHeaderContainerProps {
  * );
  */
 
-export default function Header({ type, pageTitle }: IHeaderContainerProps) {
+export function Header({ type, pageTitle }: IHeaderContainerProps) {
   return (
     <header className="sticky top-0 z-10 bg-primary text-white max-w-screen-sm w-full">
       <div className="container flex items-center justify-between h-14 py-4 px-4">

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -174,7 +174,7 @@ interface IHeaderContainerProps {
  * );
  */
 
-export function Header({ type, pageTitle }: IHeaderContainerProps) {
+const Header = ({ type, pageTitle }: IHeaderContainerProps) => {
   return (
     <header className="sticky top-0 z-10 bg-primary text-white max-w-screen-sm w-full">
       <div className="container flex items-center justify-between h-14 py-4 px-4">
@@ -188,4 +188,6 @@ export function Header({ type, pageTitle }: IHeaderContainerProps) {
       </div>
     </header>
   );
-}
+};
+
+export { Header };


### PR DESCRIPTION
## Overview
I change header component export from default export to named export

## Changes
**Before:** 
```
export default function Header({ type, pageTitle }: IHeaderContainerProps)
```

**After:** 
```
const Header = ({ type, pageTitle }: IHeaderContainerProps) => {
  return (
  ...
  );
};

export { Header };
```

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code