### PR TITLE
refactor: move `AssignedData` types to specific file

### DIFF
--- a/src/app/api/[[...route]]/routes/rotation.route.ts
+++ b/src/app/api/[[...route]]/routes/rotation.route.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 
 import prisma from '@/lib/prisma';
-import type { IAssignedData } from '@/types/commons';
+import type { IAssignedData } from '@/types/server';
 
 const app = new Hono();
 

--- a/src/app/api/[[...route]]/routes/sharehouses.ruote.ts
+++ b/src/app/api/[[...route]]/routes/sharehouses.ruote.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
-import type { IAssignedData } from '@/types/commons';
+import type { IAssignedData } from '@/types/server';
 
 const app = new Hono();
 

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -32,35 +32,3 @@ export interface ITenant {
   name: string;
   email: string;
 }
-
-/**
- * The object structure for AssignedTask
- *
- * @note This type is mainly used in the backend.
- */
-export interface IAssignedTask extends ITask {
-  isCompleted: boolean;
-}
-
-/**
- * The object structure for AssignedCategory
- *
- * @note This type is mainly used in the backend.
- */
-export interface IAssignedCategory {
-  category: Omit<ICategory, 'tasks'> | null;
-  tenantPlaceholderId: number | null;
-  tenant: Omit<ITenant, 'email'> | null;
-  tasks: IAssignedTask[] | null;
-}
-
-/**
- * The object structure for AssignedData
- *
- * This replicates the JSON structure of the assignedData in the AssignmentSheet table.
- *
- * @note This type is mainly used in the backend.
- */
-export interface IAssignedData {
-  assignments: IAssignedCategory[];
-}

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,0 +1,70 @@
+import type { ICategory, ITask, ITenant } from '@/types/commons';
+
+/**
+ * The object structure for AssignedTask
+ */
+export interface IAssignedTask extends ITask {
+  isCompleted: boolean;
+}
+
+/**
+ * The object structure for AssignedCategory
+ * for when the number of tenants is equal to the number of tasks
+ */
+export interface ICategoriesEqualTenants {
+  category: Omit<ICategory, 'tasks'>;
+  tenantPlaceholderId: number;
+  tenant: Omit<ITenant, 'email'>;
+  tasks: IAssignedTask[];
+}
+
+/**
+ * The object structure for AssignedCategory
+ * for when the number of tenants is greater than the number of tasks
+ */
+export interface ICategoriesGreaterThanTenants {
+  category: Omit<ICategory, 'tasks'>;
+  tenantPlaceholderId: null;
+  tenant: Omit<ITenant, 'email'>;
+  tasks: IAssignedTask[];
+}
+
+/**
+ * The object structure for AssignedCategory
+ * for when the number of tenants is less than the number of tasks
+ */
+export interface ICategoriesLessThanTenants {
+  category: null;
+  tenantPlaceholderId: number;
+  tenant: Omit<ITenant, 'email'>;
+  tasks: null;
+}
+
+/**
+ * The object structure for AssignedCategory
+ * for when there is no tenant
+ */
+export interface ICategoryWithoutSingleTenant {
+  category: Omit<ICategory, 'tasks'>;
+  tenantPlaceholderId: number | null;
+  tenant: null;
+  tasks: null;
+}
+
+/**
+ * The object structure for AssignedCategory
+ */
+export type TAssignedCategory =
+  | ICategoriesEqualTenants
+  | ICategoriesGreaterThanTenants
+  | ICategoriesLessThanTenants
+  | ICategoryWithoutSingleTenant;
+
+/**
+ * The object structure for AssignedData
+ *
+ * @note This replicates the JSON structure of the assignedData in the AssignmentSheet table.
+ */
+export interface IAssignedData {
+  assignments: TAssignedCategory[];
+}


### PR DESCRIPTION
## Overview

I've relocated the `AssignedData` related types to `src/types/server.ts` since they are specific to the backend development. I've also detailed the `AssignedCategory` type and made it a union type.

## Changes

- Moved the `AssignedData` related types in the `src/types/commons.ts` to `src/types/server.ts` 
- Provided details type definitions for the `AssignedCategory` type

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code