### PR TITLE
feat: subtract 1 day from `endDate` in response JSON

### DIFF
--- a/src/app/api/[[...route]]/routes/rotation.route.ts
+++ b/src/app/api/[[...route]]/routes/rotation.route.ts
@@ -5,6 +5,7 @@ import { rotationCycleUpdateSchema } from '@/constants/schema';
 import prisma from '@/lib/prisma';
 import type { IAssignedData } from '@/types/server';
 import { AssignedData } from '@/services/AssignedData';
+import { addDays } from '@/utils/dates';
 
 const app = new Hono();
 
@@ -39,8 +40,12 @@ app.get('/current/:shareHouseId', async (c) => {
     if (areAllTenantsNull) {
       return c.json({
         name: shareHouseWithAssignmentSheet.name,
-        startDate: shareHouseWithAssignmentSheet.assignmentSheet.startDate,
-        endDate: shareHouseWithAssignmentSheet.assignmentSheet.endDate,
+        startDate:
+          shareHouseWithAssignmentSheet.assignmentSheet.startDate.toISOString(),
+        endDate: addDays(
+          shareHouseWithAssignmentSheet.assignmentSheet.endDate,
+          -1,
+        ).toISOString(),
         progressRate: 0,
         categories: null,
       });
@@ -88,8 +93,12 @@ app.get('/current/:shareHouseId', async (c) => {
 
     const currentRotationData = {
       name: shareHouseWithAssignmentSheet.name,
-      startDate: shareHouseWithAssignmentSheet.assignmentSheet.startDate,
-      endDate: shareHouseWithAssignmentSheet.assignmentSheet.endDate,
+      startDate:
+        shareHouseWithAssignmentSheet.assignmentSheet.startDate.toISOString(),
+      endDate: addDays(
+        shareHouseWithAssignmentSheet.assignmentSheet.endDate,
+        -1,
+      ).toISOString(),
       progressRate: progressRate,
       categories: categories,
     };
@@ -167,7 +176,7 @@ app.get('/next/:shareHouseId', async (c) => {
     const nextAssignmentData = {
       name: sharehouse.name,
       startDate: nextAssignedData.getStartDate().toISOString(),
-      endDate: nextAssignedData.getEndDate().toISOString(),
+      endDate: addDays(nextAssignedData.getEndDate(), -1).toISOString(),
       categories: nextAssignedData
         .getAssignments()
         .map((assignment) => {

--- a/src/app/api/[[...route]]/routes/tenant.route.ts
+++ b/src/app/api/[[...route]]/routes/tenant.route.ts
@@ -9,6 +9,7 @@ import {
 import prisma from '@/lib/prisma';
 import { AssignedData } from '@/services/AssignedData';
 import { IAssignedData, TRotationScheduleForecast } from '@/types/server';
+import { addDays } from '@/utils/dates';
 
 const app = new Hono();
 
@@ -243,7 +244,7 @@ app.get('/:assignmentSheetId/:tenantId', async (c) => {
 
     rotationScheduleForecast['1'] = {
       startDate: assignmentSheet.startDate.toISOString(),
-      endDate: assignmentSheet.endDate.toISOString(),
+      endDate: addDays(assignmentSheet.endDate, -1).toISOString(),
       categories: assignedCategories.map((category) => ({
         id: category.id,
         name: category.name,
@@ -273,7 +274,7 @@ app.get('/:assignmentSheetId/:tenantId', async (c) => {
 
       rotationScheduleForecast[i as 2 | 3 | 4] = {
         startDate: nextAssignedData.getStartDate().toISOString(),
-        endDate: nextAssignedData.getEndDate().toISOString(),
+        endDate: addDays(nextAssignedData.getEndDate(), -1).toISOString(),
         categories: nextAssignedCategories.map((category) => ({
           id: category.id,
           name: category.name,


### PR DESCRIPTION
## Overview

I've subtracted one day from `endDate` in every response JSON. Thus, it now correctly conveys the actual end dates.

## Changes

- Subtracted one day from `endDate` in response JSON
- Updated to return the dates as ISO 8601 strings

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code