### PR TITLE
fix: ensure new tenants can see current and future assignments

### DIFF
--- a/src/app/api/[[...route]]/routes/tenant.route.ts
+++ b/src/app/api/[[...route]]/routes/tenant.route.ts
@@ -320,13 +320,6 @@ const app = new Hono()
         assignmentSheet.endDate,
       );
 
-      /**
-       * Check if the tenant exists in the assignedData.
-       */
-      if (!assignedData.hasTenant(tenantId)) {
-        return c.json({ error: 'Tenant not found' }, 404);
-      }
-
       const rotationScheduleForecast: TRotationScheduleForecast = {
         1: {
           startDate: '',

--- a/src/app/api/[[...route]]/routes/tenant.route.ts
+++ b/src/app/api/[[...route]]/routes/tenant.route.ts
@@ -301,6 +301,17 @@ const app = new Hono()
       }
 
       /**
+       * Check if the tenant exists in the share house.
+       */
+      if (
+        !assignmentSheet.ShareHouse.RotationAssignment.tenantPlaceholders.some(
+          (tenantPlaceholder) => tenantPlaceholder.tenantId === tenantId,
+        )
+      ) {
+        return c.json({ error: 'Tenant not found' }, 404);
+      }
+
+      /**
        * Create an AssignedData instance from the assignedData in the assignmentSheet.
        */
       const assignedData = new AssignedData(


### PR DESCRIPTION
## Overview

I've fixed #263 by ensuring new tenants can also see their current and future assignments.

## Changes

- Now checks whether the given tenant exists in the share house, not in `AssignedData`

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code