### PR TITLE
feat: introduce `revalidatePage` as a wrapper for `revalidatePath`

### DIFF
--- a/src/actions/revalidation.ts
+++ b/src/actions/revalidation.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+export const revalidatePage = (path: string) => {
+  revalidatePath(path);
+};

--- a/src/actions/revalidation.ts
+++ b/src/actions/revalidation.ts
@@ -2,6 +2,24 @@
 
 import { revalidatePath } from 'next/cache';
 
+/**
+ * Revalidates a page by its path.
+ * This is useful when you want to update the cache of a page from client components.
+ *
+ * @param path - The path of the page to revalidate
+ *
+ * @example
+ * "use client";
+ * import { revalidatePage } from '@/actions/revalidation';
+ * import { usePathname } from 'next/navigation'
+ *
+ * const path = usePathname(); // Get the current path like '/sharehouses'
+ *
+ * revalidatePage(path); // Call this action after a mutation
+ *
+ * @see https://nextjs.org/docs/app/api-reference/functions/revalidatePath
+ * @see https://nextjs.org/docs/app/api-reference/functions/use-pathname
+ */
 export const revalidatePage = (path: string) => {
   revalidatePath(path);
 };


### PR DESCRIPTION
## Overview

I've implemented a wrapper method for `revalidatePath` called `revalidatePage`. This method makes it possible to revalidate a page's cache from server components.

## Changes

- Added `revalidatePage` method in `/src/actions/revalidation`
- Described the function including its usage

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code