### PR TITLE
feat: integrate post api into category creation drawer

### DIFF
--- a/src/components/ui/ShareHouseManagementHead.tsx
+++ b/src/components/ui/ShareHouseManagementHead.tsx
@@ -45,6 +45,7 @@ export const ShareHouseManagementHead = ({
       </div>
       <div className="h-0">
         <CategoryCreationDrawer
+          shareHouseId={shareHouseId}
           open={openTaskDrawer}
           setOpen={setOpenTaskDrawer}
         />


### PR DESCRIPTION
## Overview
I integrated post API into `CategoryCreationDrawer` component to create a new category.

## Changes
`src/components/ui/ShareHouseManagementHead.tsx`
 - Add `shareHouseId` to props for `CategoryCreationDrawer`
`src/components/ui/drawers/CategoryCreationDrawer.tsx`
 - integrated post method to submit action
 - Pass `shareHouseId` to `CategoryCreationDrawer` component
 - Fix the way to invoke `LoadingSpinner` component

## Review points
-  Display a success toast when it's completed without errors
-  Display an error toast with an error from the backend when it fails

## Assignee Checklist:
- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] Code readability and simplicity
- [x] Follows best practices and coding standards
- [x] Understandable and maintainable code