### PR TITLE
feat: integrate `post` and `patch` api into task creation drawer

### DIFF
--- a/src/components/ui/drawers/CategoryCreationDrawer.tsx
+++ b/src/components/ui/drawers/CategoryCreationDrawer.tsx
@@ -319,7 +319,7 @@ interface ICategoryCreationDrawer {
  * const [open, setOpen] = useState(false);
  *
  * // To create a new category
- * <TaskCreationDrawer open={open} setOpen={setOpen} type={'categoryCreation'}/>
+ * <CategoryCreationDrawer open={open} setOpen={setOpen} type={'categoryCreation'}/>
  *
  */
 export const CategoryCreationDrawer = ({


### PR DESCRIPTION
## Overview
I integrated post API into `TaskCreationDrawer` component to create a new category.

## Changes
`src/components/ui/drawers/CategoryCreationDrawer.tsx`
- Modify component name in tsdoc example.

`src/components/ui/drawers/TaskCreationDrawer.tsx`
- integrate `post` and `patch` api into task creation drawer

## Review points
- Display a success toast when it's completed without errors
- Display an error toast with an error from the backend when it fails
(ex: if the number of tasks reaches 20, an error message is displayed.)

## Notes
- Calling POST `/api/task`, not `/api/task/:share_house_id` to add new tasks.
- After submitting data, the order of tasks are changed. We need to fix it.
- Currently, the number of tasks reaches 21, an error message is displayed. It must be 20, so we need to fix it.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code