### PR TITLE
feat: remove `modal` prop from drawer component

### DIFF
--- a/src/components/ui/commons/CommonDrawer.tsx
+++ b/src/components/ui/commons/CommonDrawer.tsx
@@ -64,13 +64,22 @@ export const CommonDrawer = <T extends FieldValues>({
     handleSubmit,
   } = useFormContext<T>();
 
+  const onOpenChange = (open: boolean) => {
+    /**
+     * Prevent the drawer from closing if the form is submitting
+     */
+    if (isSubmitting && !open) return;
+
+    setOpen(open);
+  };
+
   return (
     <>
       {/* Lading spinner if the loadingSpinner === true */}
       {onSubmit && <LoadingSpinner isLoading={isSubmitting} />}
 
       {/* Drawer */}
-      <Drawer open={open} onOpenChange={setOpen} modal={!isSubmitting}>
+      <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerTrigger />
         <DrawerContent className={className} asChild={!!onSubmit}>
           {onSubmit ? (

--- a/src/components/ui/loadingSpinner.tsx
+++ b/src/components/ui/loadingSpinner.tsx
@@ -31,7 +31,7 @@ export const LoadingOverlay = () => {
 
   return (
     <>
-      <div className="fixed left-0 top-0 z-[9999] bg-black/50 w-full h-full flex justify-center items-center">
+      <div className="fixed left-0 top-0 z-[9999] bg-black/50 w-full h-full flex justify-center items-center pointer-events-auto">
         <div className=" border-gray-200 h-12 w-12 animate-spin rounded-full border-4 border-t-primary" />
       </div>
     </>


### PR DESCRIPTION
## Overview

I've removed the `modal` prop from the `CommonDrawer` component while maintaining the same functionality. This also fixes the issue that the animation on closing doesn't play correctly. 

## Changes

- Removed the `modal` prop from the `CommonDrawer` component
- Added `pointer-events-auto` to the `LoadingSpinner` component
- Added `onOpenChange` method that prevents the drawer from closing when the form is submitting

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code