### PR TITLE
feat: ensure consistent `TenantPlaceholder` reassignment after tenant deletion

### DIFF
--- a/src/services/AssignedData.ts
+++ b/src/services/AssignedData.ts
@@ -11,7 +11,7 @@ import {
   TPrismaTenantPlaceholder,
 } from '@/types/server';
 import { addDays } from '@/utils/dates';
-import { RotationCycle } from '@/types/commons';
+import { ITenant, RotationCycle } from '@/types/commons';
 
 /**
  * Represents the assigned data for a specific rotation period based on a given assignedData.
@@ -48,6 +48,25 @@ export class AssignedData {
    */
   public getAssignments = (): TAssignedCategory[] =>
     this.assignedData.assignments;
+
+  /**
+   * Returns the tenant placeholders with tenants in the current rotation
+   */
+  public getTenantPlaceholders = (): {
+    index: number;
+    tenant: Omit<ITenant, 'email'> | null;
+  }[] => {
+    return this.assignedData.assignments
+      .map((assignment) => {
+        if (assignment.tenantPlaceholderId === null) return null;
+
+        return {
+          index: assignment.tenantPlaceholderId,
+          tenant: assignment.tenant,
+        };
+      })
+      .filter((placeholder) => placeholder !== null);
+  };
 
   /**
    * Retrieves the tenants in the current rotation


### PR DESCRIPTION
## Overview

I have ensured that in the process of deleting a tenant after adding one, there are no discrepancies or conflicts compared to when adding a tenant after deleting one.

**Before:**
When deleting Tenant B after adding Tenant D, the table looked like this.
```
TenantPlaceholder 1 - Tenant A
TenantPlaceholder 2 - null
TenantPlaceholder 3 - Tenant C
TenantPlaceholder 4 - Tenant D
```

**After:**
With b33615935588241df07d37c80ecb9625decaa6d6, it now automatically reassigns tenants by checking for a `TenantPlaceholder` that does not have a tenant assigned, in ascending order:
```
TenantPlaceholder 1 - Tenant A
TenantPlaceholder 2 - Tenant D
TenantPlaceholder 3 - Tenant C
TenantPlaceholder 4 - null
```
**_I've demonstrated this in the video below._**

## Changes

- Added a new method `getTenantPlaceholders` in the `AssignedData` class
- Added the `TenantPlaceholder` reassignment after tenant deletion on `DELETE /api/tenant/:tenantId`

## Screenshots or videos

https://www.youtube.com/watch?v=QCGnna8u4_E


## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code