### PR TITLE
feat: sort data before generating `AssignedData`

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -288,11 +288,19 @@ const main = async () => {
           select: {
             rotationCycle: true,
             categories: {
-              include: { tasks: true },
+              include: {
+                tasks: {
+                  orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+                },
+              },
+              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
             },
             tenantPlaceholders: {
               include: {
                 tenant: true,
+              },
+              orderBy: {
+                index: 'asc',
               },
             },
           },

--- a/src/app/api/[[...route]]/routes/assignments.route.ts
+++ b/src/app/api/[[...route]]/routes/assignments.route.ts
@@ -31,12 +31,18 @@ const app = new Hono()
                   rotationCycle: true,
                   categories: {
                     include: {
-                      tasks: true,
+                      tasks: {
+                        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+                      },
                     },
+                    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
                   },
                   tenantPlaceholders: {
                     include: {
                       tenant: true,
+                    },
+                    orderBy: {
+                      index: 'asc',
                     },
                   },
                 },

--- a/src/app/api/[[...route]]/routes/rotation.route.ts
+++ b/src/app/api/[[...route]]/routes/rotation.route.ts
@@ -39,12 +39,18 @@ const app = new Hono()
               rotationCycle: true,
               categories: {
                 include: {
-                  tasks: true,
+                  tasks: {
+                    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+                  },
                 },
+                orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
               },
               tenantPlaceholders: {
                 include: {
                   tenant: true,
+                },
+                orderBy: {
+                  index: 'asc',
                 },
               },
             },

--- a/src/app/api/[[...route]]/routes/sharehouse.route.ts
+++ b/src/app/api/[[...route]]/routes/sharehouse.route.ts
@@ -480,11 +480,19 @@ const app = new Hono()
               select: {
                 rotationCycle: true,
                 categories: {
-                  include: { tasks: true },
+                  include: {
+                    tasks: {
+                      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+                    },
+                  },
+                  orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
                 },
                 tenantPlaceholders: {
                   include: {
                     tenant: true,
+                  },
+                  orderBy: {
+                    index: 'asc',
                   },
                 },
               },


### PR DESCRIPTION
## Overview

I've added `orderBy` clauses to sort categories, tasks, and tenant placeholders before generating an `AssignedData` so that the data is always organized consistently.

## Changes

- Added `orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]` to sort categories and tasks by `createdAt` and `id` in ascending order
- Added `orderBy: { index: 'asc' }` to sort tenant placeholders by `index` in ascending order

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code