### PR TITLE
fix: add `asChild` to button component to fix `tab` behaviour

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -71,7 +71,7 @@ const ForgotPasswordPage = async ({
       </div>
       <ForgotPasswordRequestForm />
       <div className="flex justify-center">
-        <Button type="button" variant={'link'}>
+        <Button type="button" variant={'link'} asChild>
           <Link href="/login" className={'text-[1rem]'}>
             Back to log in
           </Link>


### PR DESCRIPTION
## Overview
I fixed `Back to log in` link on the Forgot-password page.
Before fixing, each of `<Button>` component and `<Link>` component were focused.

## Changes
- Added `asChild` to `<Button>` component

## Review points
- Check clickable area of `Back to log in` link on the Forgot-password page.
- Check tab` behaviour of `Back to log in` link

## Screenshots or videos
https://github.com/user-attachments/assets/7a917388-1f03-4eaf-b10d-c4bb4c2f5f72

## Notes
You can check how to use `Link` component with `Button` component on shadcn
[Link](https://ui.shadcn.com/docs/components/button)
![Screenshot 2024-08-13 at 9 19 24 AM](https://github.com/user-attachments/assets/8b26dc70-11e4-4c48-aebc-8e889a6ed44e)

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code