### PR TITLE
fix: correct ordering and session issues

### DIFF
--- a/src/app/api/[[...route]]/middlewares/sharehouses-loader.middleware.ts
+++ b/src/app/api/[[...route]]/middlewares/sharehouses-loader.middleware.ts
@@ -66,6 +66,7 @@ export const sharehousesLoaderMiddleware = createMiddleware<THonoEnv>(
               },
             },
           },
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
         },
       },
     });

--- a/src/app/api/[[...route]]/routes/sharehouse.route.ts
+++ b/src/app/api/[[...route]]/routes/sharehouse.route.ts
@@ -37,37 +37,20 @@ const app = new Hono<THonoEnv>()
           404,
         );
 
+      const tenants = c.var.getTenantsBySharehouseId(
+        shareHouseId,
+        'tenantCreatedAt',
+      );
+      const categories = c.var.getCategoriesBySharehouseId(shareHouseId);
+
       const { assignmentSheet, RotationAssignment, name } = doesShareHouseExist;
 
       const shareHouseData = {
         name,
         nextRotationStartDate: assignmentSheet.endDate.toISOString(),
-        tenants: RotationAssignment.tenantPlaceholders
-          .map((tenantPlaceholder) => {
-            if (tenantPlaceholder.tenant) {
-              return {
-                id: tenantPlaceholder.tenant.id,
-                name: tenantPlaceholder.tenant.name,
-                email: tenantPlaceholder.tenant.email,
-                createdAt: tenantPlaceholder.tenant.createdAt,
-              };
-            }
-            return null;
-          })
-          .filter((tenantPlaceholder) => tenantPlaceholder !== null),
-
+        tenants,
         rotationCycle: RotationAssignment.rotationCycle,
-        categories: RotationAssignment.categories.map((category) => ({
-          id: category.id,
-          name: category.name,
-          tasks: category.tasks.map((task) => ({
-            id: task.id,
-            title: task.title,
-            description: task.description,
-            createdAt: task.createdAt,
-          })),
-          createdAt: category.createdAt,
-        })),
+        categories,
       };
 
       return c.json(shareHouseData);

--- a/src/types/hono-env.ts
+++ b/src/types/hono-env.ts
@@ -25,6 +25,7 @@ export type THonoEnv = {
     ) => TSanitizedPrismaShareHouse['RotationAssignment']['categories'][0]['tasks'];
     getTenantsBySharehouseId: (
       sharehouseId: string,
+      orderBy?: 'placeholderIndex' | 'tenantCreatedAt',
     ) => NonNullable<
       TSanitizedPrismaShareHouse['RotationAssignment']['tenantPlaceholders'][0]['tenant']
     >[];


### PR DESCRIPTION
## Overview

I’ve fixed the incorrect tenant ordering on the edit page, the incorrect shared house ordering on the dashboard page, and the session issue in middleware that I accidentally introduced in PR #352.

## Changes

- With e04282340204ae872f96f190805dfa7df0f414f2, this fixes the bug where no error was thrown even though the landlord ID associated with the session did not exist in the database. This often occurred when the database was reset without logging out.

- With 4e0c8db3dbea5859ea7a6893deb2105ad658bd87, this fixes the shared houses' ordering problem. It will now sorted by the `createdAt` column in an ascending order on the dashboard page.

- With f361b3c818f905f0f56c8c0d8d6a4c0ccd3ffc5d, this fixes the tenants' ordering problem. It will now sorted by the `createdAt` column of tenant records in an ascending order on the edit page.

## Review points

Please verify those bugs are correctly fixed. Thank you in advance.

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code