### PR TITLE
fix: correct incorrect `extraAssignedCount` calculation for new shared house

### DIFF
--- a/src/app/api/[[...route]]/routes/sharehouse.route.ts
+++ b/src/app/api/[[...route]]/routes/sharehouse.route.ts
@@ -401,6 +401,23 @@ const app = new Hono<THonoEnv>()
           });
 
           /**
+           * Update each tenant with the extra assigned count.
+           */
+          for (const tenantPlaceholder of sharehouse.RotationAssignment
+            .tenantPlaceholders) {
+            const { tenant, tenantId } = tenantPlaceholder;
+
+            if (!tenant || !tenantId) continue;
+
+            await prisma.tenant.update({
+              where: { id: tenantId },
+              data: {
+                extraAssignedCount: tenant.extraAssignedCount,
+              },
+            });
+          }
+
+          /**
            * Send emails to each tenant with their personalized link
            */
           try {


### PR DESCRIPTION
## Overview

I've fixed the `POST /api/sharehouse` to update tenants' `extraAssignedCount` when creating a new shared house. Also, I've increased the `maxWait` and `timeout` times to resolve a timeout issue that previously caused failures during the creation of a new shared house.

## Changes

- Added `extraAssingedCount` calculation during the creation of a new shared house
- Increased `maxWait` and `timeout` settings to 15 seconds

## Review points

Please check if the `extraAssignedCount` is accurately updated when a tenant is assigned to multiple categories during the initial shared house setup process. 

## Screenshots or videos

<img src="https://github.com/user-attachments/assets/f967f0b5-f60e-4d6a-b8b7-09cc21c8ba88" width="200" />
<img src="https://github.com/user-attachments/assets/1b2c6dcb-91b3-4a57-ac24-526ab08e05c7" width="200" />

**As you can see, it's fixed.**
Please refer to the images in #381 for the previous wrong version

## Assignee Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [x] The base branch is correct (no accidental merges)
- [x] The branch name follows our branch naming rules
- [x] The PR title follows our PR title rules
- [x] My code follows our coding style
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors in the console

## Reviewer Checklist:

<!-- Tick the checkboxes if you have done the following: -->

- [ ] Code readability and simplicity
- [ ] Follows best practices and coding standards
- [ ] Understandable and maintainable code